### PR TITLE
802.1Q validate is No.0

### DIFF
--- a/opennebula/resource_opennebula_virtual_network.go
+++ b/opennebula/resource_opennebula_virtual_network.go
@@ -675,7 +675,7 @@ func generateVnXML(d *schema.ResourceData) (string, error) {
 	vnautovlan := "0"
 	var vnvlan string
 
-	if validVlanType(vnmad) > 0 {
+	if validVlanType(vnmad) >= 0 {
 		if d.Get("automatic_vlan_id") == true {
 			vnautovlan = "1"
 		} else if vlanid, ok := d.GetOk("vlan_id"); ok {


### PR DESCRIPTION
type 802.1Q do not set vlanid,
for return 0 from validVlanType

```
Error: OpenNebula error [INTERNAL]: [one.vn.allocate] VLAN_ID (or AUTOMATIC_VLAN_ID) is mandatory for driver 802.1Q
```