### PR TITLE
Add missing code fence

### DIFF
--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -139,6 +139,7 @@ To import an existing virtual machine #42 into Terraform, add this declaration t
 resource "opennebula_virtual_machine" "importvm" {
     name = "importedvm"
 }
+```
 
 And then run:
 


### PR DESCRIPTION
In the docs on the website, there is a missing code fence ``` which throws off the formatting.