### PR TITLE
Add attribute desired_state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ OpenNebula provider issue: ([#16](https://github.com/terraform-providers/terrafo
 * resource/opennebula_virtual_machine: Add support for tags ([#22](https://github.com/terraform-providers/terraform-provider-opennebula/issues/22))
 * resource/opennebula_virtual_machine_group: Add support for tags ([#22](https://github.com/terraform-providers/terraform-provider-opennebula/issues/22))
 * resource/opennebula_virtual_network: Add support for tags ([#22](https://github.com/terraform-providers/terraform-provider-opennebula/issues/22))
+* resource/opennebula_virtual_machine: Add support for desired_state ([#34](https://github.com/terraform-providers/terraform-provider-opennebula/issues/34))
 
 ENHANCEMENTS:
 * all resources: use Goca dynamic templates to build entities

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -86,6 +86,7 @@ The following arguments are supported:
 * `vmgroup` - (Optional) See [VM group parameters](#os-vmg) below for details. Changing this argument triggers a new resource.
 * `group` - (Optional) Name of the group which owns the virtual machine. Defaults to the caller primary group.
 * `tags` - (Optional) Virtual Machine tags.
+* `desired_state` - (Optional) The desired state of the VM, which can be ignore, running, stopped, suspended, undeployed or poweroff. Defaults to ignore.
 
 ### Graphics parameters
 


### PR DESCRIPTION
This is similar to google's desired_state attribute which can put a virtual machine in a terminated or running state. However, the goal is to allow designating every state which can be resumed from. To change between inactive states, the virtual machine is started and then the relevant action is called.