### PR TITLE
Adding "labels" to resource_opennebula_templates

### DIFF
--- a/opennebula/resource_opennebula_template_test.go
+++ b/opennebula/resource_opennebula_template_test.go
@@ -35,6 +35,7 @@ func TestAccTemplate(t *testing.T) {
 					resource.TestCheckResourceAttr("opennebula_template.template", "tags.%", "2"),
 					resource.TestCheckResourceAttr("opennebula_template.template", "tags.env", "prod"),
 					resource.TestCheckResourceAttr("opennebula_template.template", "tags.customer", "test"),
+					resource.TestCheckResourceAttr("opennebula_template.template", "label", "test1,test2,test3"),
 					resource.TestCheckResourceAttrSet("opennebula_template.template", "uid"),
 					resource.TestCheckResourceAttrSet("opennebula_template.template", "gid"),
 					resource.TestCheckResourceAttrSet("opennebula_template.template", "uname"),
@@ -65,6 +66,7 @@ func TestAccTemplate(t *testing.T) {
 					resource.TestCheckResourceAttr("opennebula_template.template", "tags.env", "dev"),
 					resource.TestCheckResourceAttr("opennebula_template.template", "tags.customer", "test"),
 					resource.TestCheckResourceAttr("opennebula_template.template", "tags.version", "2"),
+					resource.TestCheckResourceAttr("opennebula_template.template", "label", "test1,test2,test3,test4"),
 					resource.TestCheckResourceAttrSet("opennebula_template.template", "uid"),
 					resource.TestCheckResourceAttrSet("opennebula_template.template", "gid"),
 					resource.TestCheckResourceAttrSet("opennebula_template.template", "uname"),
@@ -162,6 +164,8 @@ resource "opennebula_template" "template" {
 	boot = ""
   }
 
+  labels = "test1,test2,test3"
+
   tags = {
     env = "prod"
     customer = "test"
@@ -194,6 +198,8 @@ resource "opennebula_template" "template" {
 	arch = "x86_64"
 	boot = ""
   }
+
+  labels = "test1,test2,test3,test4"
 
   tags = {
     env = "dev"

--- a/opennebula/shared_schemas.go
+++ b/opennebula/shared_schemas.go
@@ -343,6 +343,11 @@ func generateVMTemplate(d *schema.ResourceData, tpl *vm.Template) {
 		tpl.VCPU(vmvcpu.(int))
 	}
 
+	labels, ok := d.GetOk("labels")
+	if ok {
+		tpl.AddPair("LABELS", labels.(string))
+	}
+
 	tagsInterface := d.Get("tags").(map[string]interface{})
 	for k, v := range tagsInterface {
 		tpl.AddPair(strings.ToUpper(k), v)
@@ -365,6 +370,9 @@ func flattenTemplate(d *schema.ResourceData, vmTemplate *vm.Template, tplTags bo
 	arch, _ := vmTemplate.GetOS(vmk.Arch)
 	boot, _ := vmTemplate.GetOS(vmk.Boot)
 
+	// Labels
+	labels, _ := vmTemplate.Get("LABELS")
+
 	// Graphics
 	graphMap := make([]map[string]interface{}, 0, 1)
 	listen, _ := vmTemplate.GetIOGraphic(vmk.Listen)
@@ -377,6 +385,14 @@ func flattenTemplate(d *schema.ResourceData, vmTemplate *vm.Template, tplTags bo
 
 	// Nics
 	nicList := make([]interface{}, 0, 1)
+
+	// Set Labels
+	if labels != "" {
+		err = d.Set("labels", labels)
+		if err != nil {
+			return err
+		}
+	}
 
 	// Set VM Group to resource
 	if vmgIdStr != "" {


### PR DESCRIPTION
In the ONE templates for virtual machines you can
add an LABELS entry with a coma separated list.

Deprectating "template" turned this impossible.

This si an attempt to get this option back.