### PR TITLE
Allow update of VM disks

### DIFF
--- a/opennebula/helpers_vm.go
+++ b/opennebula/helpers_vm.go
@@ -1,0 +1,126 @@
+package opennebula
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/OpenNebula/one/src/oca/go/src/goca"
+	"github.com/OpenNebula/one/src/oca/go/src/goca/schemas/shared"
+	vmk "github.com/OpenNebula/one/src/oca/go/src/goca/schemas/vm/keys"
+)
+
+// return disk configuration with image_id that only appear on refDisks side
+func disksConfigDiff(refDisks, disks []interface{}) []map[string]interface{} {
+
+	// get the list of disks ID to detach
+	diffConfig := make([]map[string]interface{}, 0)
+
+	for _, refDisk := range refDisks {
+		refDiskConfig := refDisk.(map[string]interface{})
+		refImageID := refDiskConfig["image_id"].(int)
+
+		diff := true
+		for _, disk := range disks {
+			diskConfig := disk.(map[string]interface{})
+			diskImageID := diskConfig["image_id"].(int)
+
+			if refImageID == diskImageID {
+				diff = false
+				break
+			}
+		}
+
+		if diff {
+			diffConfig = append(diffConfig, refDiskConfig)
+		}
+	}
+
+	return diffConfig
+}
+
+// vmDiskAttach is an helper that synchronously attach a disk
+func vmDiskAttach(vmc *goca.VMController, timeout int, diskTpl *shared.Disk) error {
+
+	imageID, err := diskTpl.GetI(shared.ImageID)
+	if err != nil {
+		return fmt.Errorf("disk template doesn't have and image ID")
+	}
+
+	log.Printf("[DEBUG] Attach image (ID:%d) as disk", imageID)
+
+	err = vmc.DiskAttach(diskTpl.String())
+	if err != nil {
+		return fmt.Errorf("can't attach image with ID:%d: %s\n", imageID, err)
+	}
+
+	// wait before checking disk
+	_, err = waitForVMState(vmc, timeout, vmDiskUpdateReadyStates...)
+	if err != nil {
+		return fmt.Errorf(
+			"waiting for virtual machine (ID:%d) to be in state %s: %s", vmc.ID, strings.Join(vmDiskUpdateReadyStates, " "), err)
+	}
+
+	// Check that disk is attached
+	vm, err := vmc.Info(false)
+	if err != nil {
+		return err
+	}
+
+	for _, attachedDisk := range vm.Template.GetDisks() {
+
+		attachedDiskImageID, _ := attachedDisk.GetI(shared.ImageID)
+		if attachedDiskImageID == imageID {
+			return nil
+		}
+	}
+
+	// If disk not attached, retrieve error message
+	vmerr, _ := vm.UserTemplate.Get(vmk.Error)
+
+	return fmt.Errorf("image %d: %s", imageID, vmerr)
+}
+
+// vmDiskDetach is an helper that synchronously detach a disk
+func vmDiskDetach(vmc *goca.VMController, timeout int, diskID int) error {
+
+	log.Printf("[DEBUG] Detach disk %d", diskID)
+
+	err := vmc.Disk(diskID).Detach()
+	if err != nil {
+		return fmt.Errorf("can't detach disk %d: %s\n", diskID, err)
+	}
+
+	// wait before checking disk
+	_, err = waitForVMState(vmc, timeout, vmDiskUpdateReadyStates...)
+	if err != nil {
+		return fmt.Errorf(
+			"waiting for virtual machine (ID:%d) to be in state %s: %s", vmc.ID, strings.Join(vmDiskUpdateReadyStates, " "), err)
+	}
+
+	// Check that disk is detached
+	vm, err := vmc.Info(false)
+	if err != nil {
+		return err
+	}
+
+	detached := true
+	for _, attachedDisk := range vm.Template.GetDisks() {
+
+		attachedDiskID, _ := attachedDisk.ID()
+		if attachedDiskID == diskID {
+			detached = false
+			break
+		}
+
+	}
+
+	if !detached {
+		// If disk still attached, retrieve error message
+		vmerr, _ := vm.UserTemplate.Get(vmk.Error)
+
+		return fmt.Errorf("disk %d: %s", diskID, vmerr)
+	}
+
+	return nil
+}

--- a/opennebula/resource_opennebula_virtual_machine.go
+++ b/opennebula/resource_opennebula_virtual_machine.go
@@ -247,15 +247,17 @@ func resourceOpennebulaVirtualMachineCreate(d *schema.ResourceData, meta interfa
 	d.SetId(fmt.Sprintf("%v", vmID))
 	vmc := controller.VM(vmID)
 
-	expectedState := "running"
+	expectedState := "RUNNING"
 	if d.Get("pending").(bool) {
-		expectedState = "hold"
+		expectedState = "HOLD"
 	}
 
-	_, err = waitForVmState(d, meta, expectedState)
+	timeout := d.Get("timeout").(int)
+	_, err = waitForVMState(vmc, timeout, expectedState)
 	if err != nil {
 		return fmt.Errorf(
-			"Error waiting for virtual machine (%s) to be in state %s: %s", expectedState, d.Id(), err)
+			"Error waiting for virtual machine (%s) to be in state %s: %s", d.Id(), expectedState, err)
+
 	}
 
 	//Set the permissions on the VM if it was defined, otherwise use the UMASK in OpenNebula
@@ -454,7 +456,8 @@ func resourceOpennebulaVirtualMachineDelete(d *schema.ResourceData, meta interfa
 		return err
 	}
 
-	_, err = waitForVmState(d, meta, "done")
+	timeout := d.Get("timeout").(int)
+	_, err = waitForVMState(vmc, timeout, "DONE")
 	if err != nil {
 		vm, _ := vmc.Info(false)
 
@@ -473,69 +476,52 @@ func resourceOpennebulaVirtualMachineDelete(d *schema.ResourceData, meta interfa
 	return nil
 }
 
-func waitForVmState(d *schema.ResourceData, meta interface{}, state string) (interface{}, error) {
-	var vm *vm.VM
-	var err error
-	//Get VM controller
-	vmc, err := getVirtualMachineController(d, meta)
-	if err != nil {
-		return vm, err
-	}
-
-	timeout := d.Get("timeout").(int)
-
-	log.Printf("Waiting for VM (%s) to be in state Done", d.Id())
+func waitForVMState(vmc *goca.VMController, timeout int, states ...string) (interface{}, error) {
 
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{"anythingelse"}, Target: []string{state},
+		Pending: []string{"anythingelse"},
+		Target:  states,
 		Refresh: func() (interface{}, string, error) {
+
 			log.Println("Refreshing VM state...")
-			if d.Id() != "" {
-				//Get VM controller
-				vmc, err = getVirtualMachineController(d, meta)
-				if err != nil {
-					return vm, "", fmt.Errorf("Could not find VM by ID %s", d.Id())
-				}
-			}
+
 			// TODO: fix it after 5.10 release
 			// Force the "decrypt" bool to false to keep ONE 5.8 behavior
-			vm, err = vmc.Info(false)
+			vmInfos, err := vmc.Info(false)
 			if err != nil {
+				// TODO: errors messages shouldn't be parsed
 				if strings.Contains(err.Error(), "Error getting") {
 					// Do not return an error here as it is excpected if the VM is already in DONE state
 					// after its destruction
-					return vm, "notfound", nil
+					return vmInfos, "notfound", nil
 				}
-				return vm, "", err
+				return vmInfos, "", err
 			}
-			vmState, vmLcmState, err := vm.State()
+
+			vmState, vmLcmState, err := vmInfos.State()
 			if err != nil {
-				if strings.Contains(err.Error(), "Error getting") {
-					// Do not return an error here as it is excpected if the VM is already in DONE state
-					// after its destruction
-					return vm, "notfound", nil
+				return vmInfos, "", err
+			}
+			log.Printf("VM (ID:%d, name:%s) is currently in state %s and in LCM state %s", vmInfos.ID, vmInfos.Name, vmState.String(), vmLcmState.String())
+
+			switch vmState {
+
+			case vm.Done, vm.Hold:
+				return vmInfos, vmState.String(), nil
+			case vm.Active:
+				switch vmLcmState {
+				case vm.Running:
+					return vmInfos, vmLcmState.String(), nil
+				case vm.BootFailure, vm.PrologFailure, vm.EpilogFailure:
+					vmerr, _ := vmInfos.UserTemplate.Get(vmk.Error)
+					return vmInfos, vmLcmState.String(), fmt.Errorf("VM (ID:%d) entered fail state, error: %s", vmInfos.ID, vmerr)
+				default:
+					return vmInfos, "anythingelse", nil
 				}
-				return vm, "", err
+			default:
+				return vmInfos, "anythingelse", nil
 			}
-			log.Printf("VM %v is currently in state %v and in LCM state %v", vm.ID, vmState, vmLcmState)
-			if vmState == 3 && vmLcmState == 3 {
-				return vm, "running", nil
-			} else if vmState == 6 {
-				return vm, "done", nil
-			} else if vmState == 2 && vmLcmState == 0 {
-				return vm, "hold", nil
-			} else if vmState == 3 && vmLcmState == 36 {
-				vmerr, _ := vm.UserTemplate.Get(vmk.Error)
-				return vm, "boot_failure", fmt.Errorf("VM ID %s entered fail state, error message: %s", d.Id(), vmerr)
-			} else if vmState == 3 && vmLcmState == 39 {
-				vmerr, _ := vm.UserTemplate.Get(vmk.Error)
-				return vm, "prolog_failure", fmt.Errorf("VM ID %s entered fail state, error message: %s", d.Id(), vmerr)
-			} else if vmState == 3 && vmLcmState == 40 {
-				vmerr, _ := vm.UserTemplate.Get(vmk.Error)
-				return vm, "epilog_failure", fmt.Errorf("VM ID %s entered fail state, error message: %s", d.Id(), vmerr)
-			} else {
-				return vm, "anythingelse", nil
-			}
+
 		},
 		Timeout:    time.Duration(timeout) * time.Minute,
 		Delay:      10 * time.Second,

--- a/opennebula/shared_schemas.go
+++ b/opennebula/shared_schemas.go
@@ -70,7 +70,6 @@ func diskSchema() *schema.Schema {
 	return &schema.Schema{
 		Type:        schema.TypeList,
 		Optional:    true,
-		Computed:    true,
 		Description: "Definition of disks assigned to the Virtual Machine",
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
@@ -78,10 +77,13 @@ func diskSchema() *schema.Schema {
 					Type:     schema.TypeInt,
 					Required: true,
 				},
+				"disk_id": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
 				"size": {
 					Type:     schema.TypeInt,
 					Computed: true,
-					Optional: true,
 				},
 				"target": {
 					Type:     schema.TypeString,
@@ -427,10 +429,12 @@ func flattenTemplate(d *schema.ResourceData, vmTemplate *vm.Template, tplTags bo
 		size, _ := disk.GetI(shared.Size)
 		driver, _ := disk.Get(shared.Driver)
 		target, _ := disk.Get(shared.TargetDisk)
-		imageId, _ := disk.GetI(shared.ImageID)
+		imageID, _ := disk.GetI(shared.ImageID)
+		diskID, _ := disk.GetI(shared.DiskID)
 
 		diskList = append(diskList, map[string]interface{}{
-			"image_id": imageId,
+			"image_id": imageID,
+			"disk_id":  diskID,
 			"size":     size,
 			"target":   target,
 			"driver":   driver,

--- a/opennebula/shared_schemas.go
+++ b/opennebula/shared_schemas.go
@@ -221,6 +221,30 @@ func tagsSchema() *schema.Schema {
 	}
 }
 
+func makeDiskVector(diskConfig map[string]interface{}) *shared.Disk {
+	disk := shared.NewDisk()
+
+	for k, v := range diskConfig {
+
+		if isEmptyValue(reflect.ValueOf(v)) {
+			continue
+		}
+
+		switch k {
+		case "target":
+			disk.Add(shared.TargetDisk, v.(string))
+		case "driver":
+			disk.Add(shared.Driver, v.(string))
+		case "size":
+			disk.Add(shared.Size, strconv.Itoa(v.(int)))
+		case "image_id":
+			disk.Add(shared.ImageID, strconv.Itoa(v.(int)))
+		}
+	}
+
+	return disk
+}
+
 func generateVMTemplate(d *schema.ResourceData, tpl *vm.Template) {
 
 	//Generate NIC definition
@@ -264,27 +288,10 @@ func generateVMTemplate(d *schema.ResourceData, tpl *vm.Template) {
 	log.Printf("Number of disks: %d", len(disks))
 
 	for i := 0; i < len(disks); i++ {
-
 		diskconfig := disks[i].(map[string]interface{})
-		disk := tpl.AddDisk()
 
-		for k, v := range diskconfig {
-
-			if isEmptyValue(reflect.ValueOf(v)) {
-				continue
-			}
-
-			switch k {
-			case "target":
-				disk.Add(shared.TargetDisk, v.(string))
-			case "driver":
-				disk.Add(shared.Driver, v.(string))
-			case "size":
-				disk.Add(shared.Size, strconv.Itoa(v.(int)))
-			case "image_id":
-				disk.Add(shared.ImageID, strconv.Itoa(v.(int)))
-			}
-		}
+		disk := makeDiskVector(diskconfig)
+		tpl.Elements = append(tpl.Elements, disk)
 	}
 
 	//Generate GRAPHICS definition


### PR DESCRIPTION
Allow to attach/detach disks to a running/poweroff VM.

Implementation details:

When a new disk is attached, only two arguments are applied, the `image_id`, and the `target`.
As a side note, I restricted the applied attributes due to `computed` configuration of the schema arguments, which keeps old values of the state in the new config (during my first tests, this tried to attach a disk with a `size` of a previously detached disk an then I had some failures...) 

To make the diff of the disk lists, I added a custom function.
I'm not happy with this so if someone know a better terraform helper to make diff on schema data structures I'm open to changes (FYI: we don't have last facilities are we are not using the terraform SDK yet).
To do this, there is also some generic external packages (for instance: https://github.com/r3labs/diff)

Issue #64 