### PR TITLE
refact goca error handling

### DIFF
--- a/opennebula/helpers.go
+++ b/opennebula/helpers.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/OpenNebula/one/src/oca/go/src/goca/errors"
 	"github.com/OpenNebula/one/src/oca/go/src/goca/schemas/shared"
 )
 
@@ -76,5 +77,18 @@ func isEmptyValue(v reflect.Value) bool {
 	case reflect.Interface, reflect.Ptr:
 		return v.IsNil()
 	}
+	return false
+}
+
+// NoExists indicate if an entity exists in checking the error code returned from an Info call
+func NoExists(err error) bool {
+
+	respErr, ok := err.(*errors.ResponseError)
+
+	// expected case, the entity does not exists so we doesn't return an error
+	if ok && respErr.Code == errors.OneNoExistsError {
+		return true
+	}
+
 	return false
 }


### PR DESCRIPTION
Use OpenNebula error codes introduced in goca by the commit `4b882f1c073daaf288ae2f26396c21af0df17813` (Jul 11, 2019 during the 5.8 One lifecycle. Thus it should be available in 5.10)

In case a resource does not exists, OpenNebula returns an error code but the http response code is still 200.

If #59  is merged first, this should probably be updated:
```
func waitForVmState(d *schema.ResourceData, meta interface{}, state string) (interface{}, error) {
...
			vm, err = vmc.Info(false)
			if err != nil {
				if strings.Contains(err.Error(), "Error getting") {
					// Do not return an error here as it is excpected if the VM is already in DONE state
					// after its destruction
					return vm, "notfound", nil
				}
				return vm, "", err
			}
...
```
There is the same kind of code for images to update.

Else, if this PR is merged first then #59 should be updated