### PR TITLE
make CI more verbose

### DIFF
--- a/.travis/tests/terraform.sh
+++ b/.travis/tests/terraform.sh
@@ -31,4 +31,4 @@ go get github.com/mattn/goveralls
 make build
 
 # Run tests
-make testacc
+TF_LOG=DEBUG make testacc

--- a/opennebula/resource_opennebula_virtual_machine.go
+++ b/opennebula/resource_opennebula_virtual_machine.go
@@ -503,18 +503,31 @@ func resourceOpennebulaVirtualMachineDelete(d *schema.ResourceData, meta interfa
 	}
 
 	timeout := d.Get("timeout").(int)
-	_, err = waitForVMState(vmc, timeout, "DONE")
+	ret, err := waitForVMState(vmc, timeout, "DONE")
 	if err != nil {
-		vm, _ := vmc.Info(false)
 
-		vmState, vmLcmState, _ := vm.State()
-		if vmLcmState.String() == "EPILOG_FAILURE" {
-			if err = vmc.TerminateHard(); err != nil {
-				return err
+		// Retry if timeout not reached
+		_, ok := err.(*resource.TimeoutError)
+		if !ok && ret != nil {
+
+			vmInfos, _ := ret.(*vm.VM)
+			vmState, vmLcmState, _ := vmInfos.State()
+			if vmState == vm.Active && vmLcmState == vm.EpilogFailure {
+
+				err := vmc.TerminateHard()
+				if err != nil {
+					return err
+				}
+
+				_, err = waitForVMState(vmc, timeout, "DONE")
+				if err != nil {
+					return err
+				}
+
+			} else {
+				return fmt.Errorf(
+					"Error waiting for virtual machine (%s) to be in state DONE: %s (state: %v, lcmState: %v)", d.Id(), err, vmState, vmLcmState)
 			}
-		} else {
-			return fmt.Errorf(
-				"Error waiting for virtual machine (%s) to be in state DONE: %s (state: %v, lcmState: %v)", d.Id(), err, vmState, vmLcmState)
 		}
 	}
 


### PR DESCRIPTION
As seen here: https://travis-ci.com/github/OpenNebula/terraform-provider-opennebula/builds/197170389

Acceptance tests are failing due to VM destruction failure.
Inforunately I don't reproduce this behavior so I trigger CI with higher logging level.

It's a sporadic failure, so race condition come to mind as a possible cause.