### PR TITLE
F-72: Allow update of VM NICs and update disks for consistency 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ FEATURES:
 * resources/opennebula_virtual_machine: Change 'image_id' disk attribute from Required to Optional ([#71](https://github.com/OpenNebula/terraform-provider-opennebula/issues/71))
 * **New Resource**: `opennebula_service`: First implementation ([oneflow](http://docs.opennebula.io/5.12/integration/system_interfaces/appflow_api.html#service)),
 * **New Resource**: `opennebula_service_template`: First implementation ([oneflow-template](http://docs.opennebula.io/5.12/integration/system_interfaces/appflow_api.html#service-template)),
+* resources/opennebula_virtual_machine: Enable VM NIC update ([#72](https://github.com/OpenNebula/terraform-provider-opennebula/issues/72))
 
 BUG FIXES:
 * resources/opennebula_virtual_network: Fix Hold IPs crash ([#67](https://github.com/OpenNebula/terraform-provider-opennebula/issues/67))

--- a/opennebula/helpers_vm.go
+++ b/opennebula/helpers_vm.go
@@ -15,7 +15,7 @@ func vmDiskAttach(vmc *goca.VMController, timeout int, diskTpl *shared.Disk) err
 
 	imageID, err := diskTpl.GetI(shared.ImageID)
 	if err != nil {
-		return fmt.Errorf("disk template doesn't have and image ID")
+		return fmt.Errorf("disk template doesn't have an image ID")
 	}
 
 	log.Printf("[DEBUG] Attach image (ID:%d) as disk", imageID)

--- a/opennebula/helpers_vm.go
+++ b/opennebula/helpers_vm.go
@@ -10,39 +10,6 @@ import (
 	vmk "github.com/OpenNebula/one/src/oca/go/src/goca/schemas/vm/keys"
 )
 
-// return disk configuration with image_id that only appear on refDisks side
-func disksConfigDiff(refDisks, disks []interface{}) []map[string]interface{} {
-
-	// get the list of disks ID to detach
-	diffConfig := make([]map[string]interface{}, 0)
-
-	for _, refDisk := range refDisks {
-		refDiskConfig := refDisk.(map[string]interface{})
-		refImageID := refDiskConfig["image_id"].(int)
-		// If the disk exists with Default ID, skip it
-		if refImageID < 0 {
-			continue
-		}
-
-		diff := true
-		for _, disk := range disks {
-			diskConfig := disk.(map[string]interface{})
-			diskImageID := diskConfig["image_id"].(int)
-
-			if refImageID == diskImageID {
-				diff = false
-				break
-			}
-		}
-
-		if diff {
-			diffConfig = append(diffConfig, refDiskConfig)
-		}
-	}
-
-	return diffConfig
-}
-
 // vmDiskAttach is an helper that synchronously attach a disk
 func vmDiskAttach(vmc *goca.VMController, timeout int, diskTpl *shared.Disk) error {
 

--- a/opennebula/resource_opennebula_template.go
+++ b/opennebula/resource_opennebula_template.go
@@ -255,6 +255,22 @@ func resourceOpennebulaTemplateRead(d *schema.ResourceData, meta interface{}) er
 		}
 	}
 
+	// Set Disks to resource
+	disks := tpl.Template.GetDisks()
+	diskList := make([]interface{}, 0, len(disks))
+
+	// Set Disks to resource
+	for _, disk := range disks {
+		diskList = append(diskList, flattenDisk(disk))
+	}
+
+	if len(diskList) > 0 {
+		err = d.Set("disk", diskList)
+		if err != nil {
+			return err
+		}
+	}
+
 	err = flattenTemplate(d, &tpl.Template, true)
 	if err != nil {
 		return err

--- a/opennebula/resource_opennebula_template.go
+++ b/opennebula/resource_opennebula_template.go
@@ -239,6 +239,22 @@ func resourceOpennebulaTemplateRead(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 
+	// Nics
+	nics := tpl.Template.GetNICs()
+	nicList := make([]interface{}, 0, len(nics))
+
+	// Set Nics to resource
+	for _, nic := range nics {
+		nicList = append(nicList, flattenNIC(nic))
+	}
+
+	if len(nicList) > 0 {
+		err = d.Set("nic", nicList)
+		if err != nil {
+			return err
+		}
+	}
+
 	err = flattenTemplate(d, &tpl.Template, true)
 	if err != nil {
 		return err

--- a/opennebula/resource_opennebula_virtual_machine.go
+++ b/opennebula/resource_opennebula_virtual_machine.go
@@ -582,9 +582,6 @@ func resourceOpennebulaVirtualMachineExists(d *schema.ResourceData, meta interfa
 
 func resourceOpennebulaVirtualMachineUpdate(d *schema.ResourceData, meta interface{}) error {
 
-	// Enable partial state mode
-	d.Partial(true)
-
 	//Get VM
 	vmc, err := getVirtualMachineController(d, meta)
 	if err != nil {
@@ -606,7 +603,6 @@ func resourceOpennebulaVirtualMachineUpdate(d *schema.ResourceData, meta interfa
 		// TODO: fix it after 5.10 release
 		// Force the "decrypt" bool to false to keep ONE 5.8 behavior
 		vm, err := vmc.Info(false)
-		d.SetPartial("name")
 		log.Printf("[INFO] Successfully updated name (%s) for VM ID %x\n", vm.Name, vm.ID)
 	}
 
@@ -617,7 +613,6 @@ func resourceOpennebulaVirtualMachineUpdate(d *schema.ResourceData, meta interfa
 				return err
 			}
 		}
-		d.SetPartial("permissions")
 		log.Printf("[INFO] Successfully updated Permissions VM %s\n", vm.Name)
 	}
 
@@ -684,7 +679,6 @@ func resourceOpennebulaVirtualMachineUpdate(d *schema.ResourceData, meta interfa
 				return fmt.Errorf("vm disk detach: %s", err)
 
 			}
-			d.SetPartial("disk")
 		}
 
 		// Attach the disks
@@ -702,7 +696,6 @@ func resourceOpennebulaVirtualMachineUpdate(d *schema.ResourceData, meta interfa
 			if err != nil {
 				return fmt.Errorf("vm disk attach: %s", err)
 			}
-			d.SetPartial("disk")
 		}
 	}
 
@@ -745,7 +738,6 @@ func resourceOpennebulaVirtualMachineUpdate(d *schema.ResourceData, meta interfa
 				return fmt.Errorf("vm nic detach: %s", err)
 
 			}
-			d.SetPartial("nic")
 		}
 
 		// Attach the nics
@@ -758,14 +750,8 @@ func resourceOpennebulaVirtualMachineUpdate(d *schema.ResourceData, meta interfa
 			if err != nil {
 				return fmt.Errorf("vm nic attach: %s", err)
 			}
-
-			d.SetPartial("nic")
 		}
 	}
-
-	// We succeeded, disable partial mode. This causes Terraform to save
-	// save all fields again.
-	d.Partial(false)
 
 	return nil
 }

--- a/opennebula/resource_opennebula_virtual_machine_test.go
+++ b/opennebula/resource_opennebula_virtual_machine_test.go
@@ -124,6 +124,14 @@ func TestAccVirtualMachineDiskUpdate(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccVirtualMachineTemplateConfigDiskTargetUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "name", "test-virtual_machine"),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "disk.#", "1"),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "disk.0.target", "vdc"),
+				),
+			},
+			{
 				Config: testAccVirtualMachineTemplateConfigDiskDetached,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "name", "test-virtual_machine"),
@@ -501,6 +509,63 @@ resource "opennebula_image" "img1" {
 	  disk {
 		  image_id = opennebula_image.img1.id
 		  target = "vdb"
+	  }
+	
+	  timeout = 5
+}
+`
+
+var testAccVirtualMachineTemplateConfigDiskTargetUpdate = `
+
+resource "opennebula_image" "img1" {
+	name             = "image1"
+	type             = "DATABLOCK"
+	size             = "16"
+	datastore_id     = 1
+	persistent       = false
+	permissions      = "660"
+  }
+  
+  resource "opennebula_image" "img2" {
+	name             = "image2"
+	type             = "DATABLOCK"
+	size             = "8"
+	datastore_id     = 1
+	persistent       = false
+	permissions      = "660"
+  }
+  
+  resource "opennebula_virtual_machine" "test" {
+	  name        = "test-virtual_machine"
+	  group       = "oneadmin"
+	  permissions = "642"
+	  memory = 128
+	  cpu = 0.1
+	
+	  context = {
+		NETWORK  = "YES"
+		SET_HOSTNAME = "$NAME"
+	  }
+	
+	  graphics {
+		type   = "VNC"
+		listen = "0.0.0.0"
+		keymap = "en-us"
+	  }
+	
+	  os {
+		arch = "x86_64"
+		boot = ""
+	  }
+	
+	  tags = {
+		env = "prod"
+		customer = "test"
+	  }
+  
+	  disk {
+		  image_id = opennebula_image.img1.id
+		  target = "vdc"
 	  }
 	
 	  timeout = 5

--- a/opennebula/resource_opennebula_virtual_machine_test.go
+++ b/opennebula/resource_opennebula_virtual_machine_test.go
@@ -134,6 +134,55 @@ func TestAccVirtualMachineDiskUpdate(t *testing.T) {
 	})
 }
 
+func TestAccVirtualMachineNICUpdate(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVirtualMachineDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVirtualMachineTemplateConfigBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccSetDSdummy(),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "name", "test-virtual_machine"),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "nic.#", "0"),
+				),
+			},
+			{
+				Config: testAccVirtualMachineTemplateConfigNIC,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "name", "test-virtual_machine"),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "nic.#", "1"),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "nic.0.ip", "172.16.100.131"),
+				),
+			},
+			{
+				Config: testAccVirtualMachineTemplateConfigNICUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "name", "test-virtual_machine"),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "nic.#", "1"),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "nic.0.ip", "172.16.100.111"),
+				),
+			},
+			{
+				Config: testAccVirtualMachineTemplateConfigNICIPUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "name", "test-virtual_machine"),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "nic.#", "1"),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "nic.0.ip", "172.16.100.112"),
+				),
+			},
+			{
+				Config: testAccVirtualMachineTemplateConfigNICDetached,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "name", "test-virtual_machine"),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "nic.#", "0"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccVirtualMachinePending(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -477,6 +526,286 @@ resource "opennebula_image" "img2" {
   persistent       = false
   permissions      = "660"
 }
+
+resource "opennebula_virtual_machine" "test" {
+	name        = "test-virtual_machine"
+	group       = "oneadmin"
+	permissions = "642"
+	memory = 128
+	cpu = 0.1
+  
+	context = {
+	  NETWORK  = "YES"
+	  SET_HOSTNAME = "$NAME"
+	}
+  
+	graphics {
+	  type   = "VNC"
+	  listen = "0.0.0.0"
+	  keymap = "en-us"
+	}
+  
+	os {
+	  arch = "x86_64"
+	  boot = ""
+	}
+  
+	tags = {
+	  env = "prod"
+	  customer = "test"
+	}
+  
+	timeout = 5
+}
+`
+
+var testAccVirtualMachineTemplateConfigNIC = `
+
+resource "opennebula_virtual_network" "net1" {
+	name = "test-net1"
+	type            = "dummy"
+	bridge          = "onebr"
+	mtu             = 1500
+	ar {
+	  ar_type = "IP4"
+	  size    = 12
+	  ip4     = "172.16.100.130"
+	}
+	permissions = "642"
+	group = "oneadmin"
+	security_groups = [0]
+	clusters = [0]
+  }
+
+  resource "opennebula_virtual_network" "net2" {
+	name = "test-net2"
+	type            = "dummy"
+	bridge          = "onebr"
+	mtu             = 1500
+	ar {
+	  ar_type = "IP4"
+	  size    = 16
+	  ip4     = "172.16.100.110"
+	}
+	permissions = "642"
+	group = "oneadmin"
+	security_groups = [0]
+	clusters = [0]
+  }
+
+
+resource "opennebula_virtual_machine" "test" {
+	name        = "test-virtual_machine"
+	group       = "oneadmin"
+	permissions = "642"
+	memory = 128
+	cpu = 0.1
+  
+	context = {
+	  NETWORK  = "YES"
+	  SET_HOSTNAME = "$NAME"
+	}
+  
+	graphics {
+	  type   = "VNC"
+	  listen = "0.0.0.0"
+	  keymap = "en-us"
+	}
+  
+	os {
+	  arch = "x86_64"
+	  boot = ""
+	}
+  
+	tags = {
+	  env = "prod"
+	  customer = "test"
+	}
+
+	nic {
+		network_id = opennebula_virtual_network.net1.id
+		ip = "172.16.100.131"
+	}
+  
+	timeout = 5
+}
+`
+
+var testAccVirtualMachineTemplateConfigNICUpdate = `
+
+resource "opennebula_virtual_network" "net1" {
+	name = "test-net1"
+	type            = "dummy"
+	bridge          = "onebr"
+	mtu             = 1500
+	ar {
+	  ar_type = "IP4"
+	  size    = 12
+	  ip4     = "172.16.100.130"
+	}
+	permissions = "642"
+	group = "oneadmin"
+	security_groups = [0]
+	clusters = [0]
+  }
+
+  resource "opennebula_virtual_network" "net2" {
+	name = "test-net2"
+	type            = "dummy"
+	bridge          = "onebr"
+	mtu             = 1500
+	ar {
+	  ar_type = "IP4"
+	  size    = 16
+	  ip4     = "172.16.100.110"
+	}
+	permissions = "642"
+	group = "oneadmin"
+	security_groups = [0]
+	clusters = [0]
+  }
+
+  resource "opennebula_virtual_machine" "test" {
+	  name        = "test-virtual_machine"
+	  group       = "oneadmin"
+	  permissions = "642"
+	  memory = 128
+	  cpu = 0.1
+	
+	  context = {
+		NETWORK  = "YES"
+		SET_HOSTNAME = "$NAME"
+	  }
+	
+	  graphics {
+		type   = "VNC"
+		listen = "0.0.0.0"
+		keymap = "en-us"
+	  }
+	
+	  os {
+		arch = "x86_64"
+		boot = ""
+	  }
+	
+	  tags = {
+		env = "prod"
+		customer = "test"
+	  }
+  
+	  nic {
+		  network_id = opennebula_virtual_network.net2.id
+		  ip = "172.16.100.111"
+	  }
+	
+	  timeout = 5
+}
+`
+
+var testAccVirtualMachineTemplateConfigNICIPUpdate = `
+
+resource "opennebula_virtual_network" "net1" {
+	name = "test-net1"
+	type            = "dummy"
+	bridge          = "onebr"
+	mtu             = 1500
+	ar {
+	  ar_type = "IP4"
+	  size    = 12
+	  ip4     = "172.16.100.130"
+	}
+	permissions = "642"
+	group = "oneadmin"
+	security_groups = [0]
+	clusters = [0]
+  }
+
+  resource "opennebula_virtual_network" "net2" {
+	name = "test-net2"
+	type            = "dummy"
+	bridge          = "onebr"
+	mtu             = 1500
+	ar {
+	  ar_type = "IP4"
+	  size    = 16
+	  ip4     = "172.16.100.110"
+	}
+	permissions = "642"
+	group = "oneadmin"
+	security_groups = [0]
+	clusters = [0]
+  }
+
+  resource "opennebula_virtual_machine" "test" {
+	  name        = "test-virtual_machine"
+	  group       = "oneadmin"
+	  permissions = "642"
+	  memory = 128
+	  cpu = 0.1
+	
+	  context = {
+		NETWORK  = "YES"
+		SET_HOSTNAME = "$NAME"
+	  }
+	
+	  graphics {
+		type   = "VNC"
+		listen = "0.0.0.0"
+		keymap = "en-us"
+	  }
+	
+	  os {
+		arch = "x86_64"
+		boot = ""
+	  }
+	
+	  tags = {
+		env = "prod"
+		customer = "test"
+	  }
+  
+	  nic {
+		  network_id = opennebula_virtual_network.net2.id
+		  ip = "172.16.100.112"
+	  }
+	
+	  timeout = 5
+}
+`
+
+var testAccVirtualMachineTemplateConfigNICDetached = `
+
+resource "opennebula_virtual_network" "net1" {
+	name = "test-net1"
+	type            = "dummy"
+	bridge          = "onebr"
+	mtu             = 1500
+	ar {
+	  ar_type = "IP4"
+	  size    = 12
+	  ip4     = "172.16.100.130"
+	}
+	permissions = "642"
+	group = "oneadmin"
+	security_groups = [0]
+	clusters = [0]
+  }
+
+  resource "opennebula_virtual_network" "net2" {
+	name = "test-net2"
+	type            = "dummy"
+	bridge          = "onebr"
+	mtu             = 1500
+	ar {
+	  ar_type = "IP4"
+	  size    = 16
+	  ip4     = "172.16.100.110"
+	}
+	permissions = "642"
+	group = "oneadmin"
+	security_groups = [0]
+	clusters = [0]
+  }
 
 resource "opennebula_virtual_machine" "test" {
 	name        = "test-virtual_machine"

--- a/opennebula/resource_opennebula_virtual_network.go
+++ b/opennebula/resource_opennebula_virtual_network.go
@@ -245,7 +245,6 @@ func resourceOpennebulaVirtualNetwork() *schema.Resource {
 			"hold_ips": {
 				Type:          schema.TypeList,
 				Optional:      true,
-				Computed:      true,
 				Description:   "List of IPs to be held the VNET",
 				ConflictsWith: []string{"reservation_vnet", "reservation_size"},
 				Elem: &schema.Schema{

--- a/opennebula/shared_schemas.go
+++ b/opennebula/shared_schemas.go
@@ -13,56 +13,59 @@ import (
 	vmk "github.com/OpenNebula/one/src/oca/go/src/goca/schemas/vm/keys"
 )
 
+func nicFields(customFields ...map[string]*schema.Schema) *schema.Resource {
+
+	fields := map[string]*schema.Schema{
+		"ip": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"mac": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"model": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"network_id": {
+			Type:     schema.TypeInt,
+			Required: true,
+		},
+		"network": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"physical_device": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"security_groups": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeInt,
+			},
+		},
+	}
+
+	for _, m := range customFields {
+		for k, v := range m {
+			fields[k] = v
+		}
+	}
+
+	return &schema.Resource{
+		Schema: fields,
+	}
+}
+
 func nicSchema() *schema.Schema {
 	return &schema.Schema{
 		Type:        schema.TypeList,
 		Optional:    true,
-		Computed:    true,
 		Description: "Definition of network adapter(s) assigned to the Virtual Machine",
-		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{
-				"ip": {
-					Type:     schema.TypeString,
-					Computed: true,
-					Optional: true,
-				},
-				"mac": {
-					Type:     schema.TypeString,
-					Computed: true,
-					Optional: true,
-				},
-				"model": {
-					Type:     schema.TypeString,
-					Computed: true,
-					Optional: true,
-				},
-				"network_id": {
-					Type:     schema.TypeInt,
-					Required: true,
-				},
-				"network": {
-					Type:     schema.TypeString,
-					Computed: true,
-				},
-				"physical_device": {
-					Type:     schema.TypeString,
-					Computed: true,
-					Optional: true,
-				},
-				"security_groups": {
-					Type:     schema.TypeList,
-					Optional: true,
-					Computed: true,
-					Elem: &schema.Schema{
-						Type: schema.TypeInt,
-					},
-				},
-				"nic_id": {
-					Type:     schema.TypeInt,
-					Computed: true,
-				},
-			},
-		},
+		Elem:        nicFields(),
 	}
 }
 
@@ -373,6 +376,35 @@ func generateVMTemplate(d *schema.ResourceData, tpl *vm.Template) {
 
 }
 
+func flattenNIC(nic shared.NIC) map[string]interface{} {
+
+	sg := make([]int, 0)
+	ip, _ := nic.Get(shared.IP)
+	mac, _ := nic.Get(shared.MAC)
+	physicalDevice, _ := nic.GetStr("PHYDEV")
+	network, _ := nic.Get(shared.Network)
+
+	model, _ := nic.Get(shared.Model)
+	networkId, _ := nic.GetI(shared.NetworkID)
+	securityGroupsArray, _ := nic.Get(shared.SecurityGroups)
+
+	sgString := strings.Split(securityGroupsArray, ",")
+	for _, s := range sgString {
+		sgInt, _ := strconv.ParseInt(s, 10, 32)
+		sg = append(sg, int(sgInt))
+	}
+
+	return map[string]interface{}{
+		"ip":              ip,
+		"mac":             mac,
+		"network_id":      networkId,
+		"physical_device": physicalDevice,
+		"network":         network,
+		"model":           model,
+		"security_groups": sg,
+	}
+}
+
 func flattenTemplate(d *schema.ResourceData, vmTemplate *vm.Template, tplTags bool) error {
 
 	var err error
@@ -397,9 +429,6 @@ func flattenTemplate(d *schema.ResourceData, vmTemplate *vm.Template, tplTags bo
 
 	// Disks
 	diskList := make([]interface{}, 0, 1)
-
-	// Nics
-	nicList := make([]interface{}, 0, 1)
 
 	// Set VM Group to resource
 	if vmgIdStr != "" {
@@ -458,47 +487,6 @@ func flattenTemplate(d *schema.ResourceData, vmTemplate *vm.Template, tplTags bo
 
 	if len(diskList) > 0 {
 		err = d.Set("disk", diskList)
-		if err != nil {
-			return err
-		}
-	}
-
-	// Set Nics to resource
-	for i, nic := range vmTemplate.GetNICs() {
-		sg := make([]int, 0)
-		ip, _ := nic.Get(shared.IP)
-		mac, _ := nic.Get(shared.MAC)
-		physicalDevice, _ := nic.GetStr("PHYDEV")
-		network, _ := nic.Get(shared.Network)
-		nicId, _ := nic.ID()
-
-		model, _ := nic.Get(shared.Model)
-		networkId, _ := nic.GetI(shared.NetworkID)
-		securityGroupsArray, _ := nic.Get(shared.SecurityGroups)
-
-		sgString := strings.Split(securityGroupsArray, ",")
-		for _, s := range sgString {
-			sgInt, _ := strconv.ParseInt(s, 10, 32)
-			sg = append(sg, int(sgInt))
-		}
-
-		nicList = append(nicList, map[string]interface{}{
-			"ip":              ip,
-			"mac":             mac,
-			"network_id":      networkId,
-			"physical_device": physicalDevice,
-			"network":         network,
-			"nic_id":          nicId,
-			"model":           model,
-			"security_groups": sg,
-		})
-		if i == 0 {
-			d.Set("ip", ip)
-		}
-	}
-
-	if len(nicList) > 0 {
-		err = d.Set("nic", nicList)
 		if err != nil {
 			return err
 		}

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -130,6 +130,8 @@ Minimum 1 item. Maximum 8 items.
 
 Minimum 1 item. Maximum 8 items.
 
+A NIC update will be triggered in adding or removing a `nic` section, or by a modification of any of these parameters: `network_id`, `ip`, `mac`, `security_groups`, `physical_device`
+
 ### VM group parameters
 
 `vmgroup` supports the following arguments:
@@ -149,6 +151,17 @@ The following attribute are exported:
 * `gname` - Group Name which owns the virtual machine.
 * `state` - State of the virtual machine.
 * `lcmstate` - LCM State of the virtual machine.
+
+
+### NIC
+
+* `nic_id` - nic attachment identifier
+* `network` - network name
+* `computed_ip` - IP of the virtual machine on this network.
+* `computed_mac` - MAC of the virtual machine on this network.
+* `computed_model` - Nic model driver.
+* `computed_physical_device` - Physical device hosting the virtual network.
+* `computed_security_groups` - List of security group IDs to use on the virtual.
 
 ## Instantiate from a template
 

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -117,6 +117,8 @@ The following arguments are supported:
 
 Minimum 1 item. Maximum 8 items.
 
+A disk update will be triggered in adding or removing a `disk` section, or by a modification of any of these parameters: `image_id`, `target`, `driver`
+
 ### NIC parameters
 
 `nic` supports the following arguments
@@ -162,6 +164,13 @@ The following attribute are exported:
 * `computed_model` - Nic model driver.
 * `computed_physical_device` - Physical device hosting the virtual network.
 * `computed_security_groups` - List of security group IDs to use on the virtual.
+
+### Disk
+
+* `disk_id` - disk attachment identifier
+* `computed_size` - Size (in MB) of the image attached to the virtual machine. Not possible to change a cloned image size.
+* `computed_target` - Target name device on the virtual machine. Depends of the image `dev_prefix`.
+* `computed_driver` - OpenNebula image driver.
 
 ## Instantiate from a template
 


### PR DESCRIPTION
This PR allow to update the NICs of a VM in a RUNNING/POWEROFF state.

But overall, the behaviour is the same that for disk update in #59
This PR remove some computed attributes around that were not useful.

I updated helpers that make diffs on list of configs (NIC, disk...)

One change that doesn't impact much the code is that a VM doesn't have transitional states when attach/detach a NIC from a VM in POWEROFF state.
To make less requests we could remove the waitForVMState call in this case.