### PR TITLE
F-72 fixes

### DIFF
--- a/opennebula/resource_opennebula_virtual_machine.go
+++ b/opennebula/resource_opennebula_virtual_machine.go
@@ -753,7 +753,7 @@ func resourceOpennebulaVirtualMachineUpdate(d *schema.ResourceData, meta interfa
 		}
 	}
 
-	return nil
+	return resourceOpennebulaVirtualMachineRead(d, meta)
 }
 
 func resourceOpennebulaVirtualMachineDelete(d *schema.ResourceData, meta interface{}) error {

--- a/opennebula/resource_opennebula_virtual_machine_test.go
+++ b/opennebula/resource_opennebula_virtual_machine_test.go
@@ -112,7 +112,7 @@ func TestAccVirtualMachineDiskUpdate(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "name", "test-virtual_machine"),
 					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "disk.#", "1"),
-					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "disk.0.target", "vda"),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "disk.0.computed_target", "vda"),
 				),
 			},
 			{
@@ -120,7 +120,7 @@ func TestAccVirtualMachineDiskUpdate(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "name", "test-virtual_machine"),
 					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "disk.#", "1"),
-					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "disk.0.target", "vdb"),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "disk.0.computed_target", "vdb"),
 				),
 			},
 			{
@@ -128,7 +128,7 @@ func TestAccVirtualMachineDiskUpdate(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "name", "test-virtual_machine"),
 					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "disk.#", "1"),
-					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "disk.0.target", "vdc"),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "disk.0.computed_target", "vdc"),
 				),
 			},
 			{
@@ -161,7 +161,7 @@ func TestAccVirtualMachineNICUpdate(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "name", "test-virtual_machine"),
 					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "nic.#", "1"),
-					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "nic.0.ip", "172.16.100.131"),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "nic.0.computed_ip", "172.16.100.131"),
 				),
 			},
 			{
@@ -169,7 +169,7 @@ func TestAccVirtualMachineNICUpdate(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "name", "test-virtual_machine"),
 					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "nic.#", "1"),
-					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "nic.0.ip", "172.16.100.111"),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "nic.0.computed_ip", "172.16.100.111"),
 				),
 			},
 			{
@@ -177,7 +177,7 @@ func TestAccVirtualMachineNICUpdate(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "name", "test-virtual_machine"),
 					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "nic.#", "1"),
-					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "nic.0.ip", "172.16.100.112"),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "nic.0.computed_ip", "172.16.100.112"),
 				),
 			},
 			{


### PR DESCRIPTION
This PR add somes fixes to #80 

- Add read operation at end of VM update method
- prefix acceptance test attribute with `computed_` for disk and NIC
