### PR TITLE
B #97: VM template_id: read disk-nic separately

### DIFF
--- a/opennebula/helpers.go
+++ b/opennebula/helpers.go
@@ -129,3 +129,17 @@ func diffListConfig(refVecs, vecs []interface{}, s *schema.Resource, attrNames .
 
 	return mSet.List(), pSet.List()
 }
+
+func mergeSchemas(schema map[string]*schema.Schema, schemas ...map[string]*schema.Schema) map[string]*schema.Schema {
+	if len(schemas) == 0 {
+		return schema
+	}
+
+	for _, m := range schemas {
+		for k, v := range m {
+			schema[k] = v
+		}
+	}
+
+	return schema
+}

--- a/opennebula/shared_schemas.go
+++ b/opennebula/shared_schemas.go
@@ -13,9 +13,9 @@ import (
 	vmk "github.com/OpenNebula/one/src/oca/go/src/goca/schemas/vm/keys"
 )
 
-func nicFields(customFields ...map[string]*schema.Schema) *schema.Resource {
+func nicFields() map[string]*schema.Schema {
 
-	fields := map[string]*schema.Schema{
+	return map[string]*schema.Schema{
 		"ip": {
 			Type:     schema.TypeString,
 			Optional: true,
@@ -48,16 +48,6 @@ func nicFields(customFields ...map[string]*schema.Schema) *schema.Resource {
 			},
 		},
 	}
-
-	for _, m := range customFields {
-		for k, v := range m {
-			fields[k] = v
-		}
-	}
-
-	return &schema.Resource{
-		Schema: fields,
-	}
 }
 
 func nicSchema() *schema.Schema {
@@ -65,12 +55,14 @@ func nicSchema() *schema.Schema {
 		Type:        schema.TypeList,
 		Optional:    true,
 		Description: "Definition of network adapter(s) assigned to the Virtual Machine",
-		Elem:        nicFields(),
+		Elem: &schema.Resource{
+			Schema: nicFields(),
+		},
 	}
 }
 
-func diskFields(customFields ...map[string]*schema.Schema) *schema.Resource {
-	fields := map[string]*schema.Schema{
+func diskFields(customFields ...map[string]*schema.Schema) map[string]*schema.Schema {
+	return map[string]*schema.Schema{
 		"image_id": {
 			Type:        schema.TypeInt,
 			Default:     -1,
@@ -90,16 +82,6 @@ func diskFields(customFields ...map[string]*schema.Schema) *schema.Resource {
 			Optional: true,
 		},
 	}
-
-	for _, m := range customFields {
-		for k, v := range m {
-			fields[k] = v
-		}
-	}
-
-	return &schema.Resource{
-		Schema: fields,
-	}
 }
 
 func diskSchema(customFields ...map[string]*schema.Schema) *schema.Schema {
@@ -107,7 +89,9 @@ func diskSchema(customFields ...map[string]*schema.Schema) *schema.Schema {
 		Type:        schema.TypeList,
 		Optional:    true,
 		Description: "Definition of disks assigned to the Virtual Machine",
-		Elem:        diskFields(),
+		Elem: &schema.Resource{
+			Schema: diskFields(),
+		},
 	}
 }
 

--- a/opennebula/shared_schemas.go
+++ b/opennebula/shared_schemas.go
@@ -403,10 +403,12 @@ func flattenNIC(nic shared.NIC) map[string]interface{} {
 	networkId, _ := nic.GetI(shared.NetworkID)
 	securityGroupsArray, _ := nic.Get(shared.SecurityGroups)
 
-	sgString := strings.Split(securityGroupsArray, ",")
-	for _, s := range sgString {
-		sgInt, _ := strconv.ParseInt(s, 10, 32)
-		sg = append(sg, int(sgInt))
+	if len(securityGroupsArray) > 0 {
+		sgString := strings.Split(securityGroupsArray, ",")
+		for _, s := range sgString {
+			sgInt, _ := strconv.ParseInt(s, 10, 32)
+			sg = append(sg, int(sgInt))
+		}
 	}
 
 	return map[string]interface{}{

--- a/opennebula/shared_schemas.go
+++ b/opennebula/shared_schemas.go
@@ -423,6 +423,9 @@ func flattenNIC(nic shared.NIC) map[string]interface{} {
 func flattenDisk(disk shared.Disk) map[string]interface{} {
 
 	size, _ := disk.GetI(shared.Size)
+	if size == -1 {
+		size = 0
+	}
 	driver, _ := disk.Get(shared.Driver)
 	target, _ := disk.Get(shared.TargetDisk)
 	imageID, _ := disk.GetI(shared.ImageID)

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -153,7 +153,29 @@ The following attribute are exported:
 * `gname` - Group Name which owns the virtual machine.
 * `state` - State of the virtual machine.
 * `lcmstate` - LCM State of the virtual machine.
+* `template_disk` - when `template_id` is used and the template define some disks, this contains the template disks description.
+* `template_nic` - when `template_id` is used and the template define some NICs, this contains the template NICs description.
 
+
+### Template NIC
+
+* `network_id` - ID of the image attached to the virtual machine.
+* `nic_id` - nic attachment identifier
+* `network` - network name
+* `computed_ip` - IP of the virtual machine on this network.
+* `computed_mac` - MAC of the virtual machine on this network.
+* `computed_model` - Nic model driver.
+* `computed_physical_device` - Physical device hosting the virtual network.
+* `computed_security_groups` - List of security group IDs to use on the virtual.
+
+
+### Template disk
+
+* `image_id` - ID of the image attached to the virtual machine.
+* `disk_id` - disk attachment identifier
+* `computed_size` - Size (in MB) of the image attached to the virtual machine. Not possible to change a cloned image size.
+* `computed_target` - Target name device on the virtual machine. Depends of the image `dev_prefix`.
+* `computed_driver` - OpenNebula image driver.
 
 ### NIC
 
@@ -178,6 +200,8 @@ When the attribute `template_id` is set, here is the behavior:
 
 For all parameters excepted context: parameters present in VM overrides parameters defined in template.
 For context: it merges them.
+
+For disks and NICs defined in the template, if they are not overriden, are described in `template_disk` and `template_nic` attributes of the instantiated VM and are not modifiable anymore.
 
 ## Import
 


### PR DESCRIPTION
Fix #97: Modify the VM schema and read step to differentiate how we process the disk added via the template, and the disk added via the TF file.

By the way there is a bit of refactoring around how I mix schemas for disk and NIC introducing the `mergeSchemas` method to add a bit of flexibility.