### PR TITLE
add computed_size attribute

### DIFF
--- a/opennebula/resource_opennebula_image.go
+++ b/opennebula/resource_opennebula_image.go
@@ -156,6 +156,10 @@ func resourceOpennebulaImage() *schema.Resource {
 				ConflictsWith: []string{"clone_from_image"},
 				Description:   "Size of the new image in MB",
 			},
+			"computed_size": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
 			"dev_prefix": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -431,6 +435,7 @@ func resourceOpennebulaImageRead(d *schema.ResourceData, meta interface{}) error
 		d.Set("persistent", *image.Persistent)
 	}
 	d.Set("path", image.Path)
+	d.Set("computed_size", image.Size)
 
 	if inArray(image.Type, imagetypes) >= 0 {
 		d.Set("type", image.Type)

--- a/opennebula/resource_opennebula_image_test.go
+++ b/opennebula/resource_opennebula_image_test.go
@@ -2,11 +2,12 @@ package opennebula
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
 	"reflect"
 	"strconv"
 	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
 
 	"github.com/OpenNebula/one/src/oca/go/src/goca"
 	"github.com/OpenNebula/one/src/oca/go/src/goca/schemas/shared"
@@ -26,6 +27,7 @@ func TestAccImage(t *testing.T) {
 					resource.TestCheckResourceAttr("opennebula_image.testimage", "persistent", "true"),
 					resource.TestCheckResourceAttr("opennebula_image.testimage", "type", "DATABLOCK"),
 					resource.TestCheckResourceAttr("opennebula_image.testimage", "size", "128"),
+					resource.TestCheckResourceAttr("opennebula_image.testimage", "computed_size", "128"),
 					resource.TestCheckResourceAttr("opennebula_image.testimage", "dev_prefix", "vd"),
 					resource.TestCheckResourceAttr("opennebula_image.testimage", "driver", "qcow2"),
 					resource.TestCheckResourceAttr("opennebula_image.testimage", "permissions", "742"),
@@ -54,6 +56,7 @@ func TestAccImage(t *testing.T) {
 					resource.TestCheckResourceAttr("opennebula_image.testimage", "persistent", "false"),
 					resource.TestCheckResourceAttr("opennebula_image.testimage", "type", "DATABLOCK"),
 					resource.TestCheckResourceAttr("opennebula_image.testimage", "size", "128"),
+					resource.TestCheckResourceAttr("opennebula_image.testimage", "computed_size", "128"),
 					resource.TestCheckResourceAttr("opennebula_image.testimage", "dev_prefix", "vd"),
 					resource.TestCheckResourceAttr("opennebula_image.testimage", "driver", "qcow2"),
 					resource.TestCheckResourceAttr("opennebula_image.testimage", "permissions", "660"),

--- a/website/docs/r/image.html.markdown
+++ b/website/docs/r/image.html.markdown
@@ -123,11 +123,13 @@ The following arguments are supported:
 ## Attribute Reference
 
 The following attributes are exported:
+
 * `id` - ID of the image.
 * `uid` - User ID whom owns the image.
 * `gid` - Group ID which owns the image.
 * `uname` - User Name whom owns the image.
 * `gname` - Group Name which owns the image.
+* `computed_size` - Size of the image in MB.
 
 ## Import
 


### PR DESCRIPTION
This PR, related to #104 issue, adds `computed_size` attribute to image entities but doesn't affect the size attribute.

In case of disk resize of a VM, a persistent image will be resized as well on the cloud provider side, but the provider won't fill the image `computed_size` in state.
The reason is: we modify an image indirectly, i.e. via a change on an other entity, a VM. A change on a VM won't trigger a read operation on an image.  
To fix the `computed_size` value, we just need to run `terraform refresh`.