### PR TITLE
F-131: improve vnet ar update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 BUG FIXES:
 * resources/opennebula_virtual_network: fix type at read for reservation_vnet
 
+ENHANCEMENTS:
+* resources/opennebula_virtual_network: Enhance address range update
+
 ## 0.3.0 (December 17, 2020)
 
 FEATURES:

--- a/opennebula/resource_opennebula_virtual_network_test.go
+++ b/opennebula/resource_opennebula_virtual_network_test.go
@@ -38,13 +38,16 @@ func TestAccVirtualNetwork(t *testing.T) {
 					resource.TestCheckResourceAttrSet("opennebula_virtual_network.test", "gid"),
 					resource.TestCheckResourceAttrSet("opennebula_virtual_network.test", "uname"),
 					resource.TestCheckResourceAttrSet("opennebula_virtual_network.test", "gname"),
-					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "ar.#", "2"),
-					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "ar.0.ar_type", "IP4"),
-					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "ar.0.size", "16"),
-					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "ar.0.ip4", "172.16.100.110"),
-					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "ar.1.ar_type", "IP4"),
-					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "ar.1.size", "12"),
-					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "ar.1.ip4", "172.16.100.130"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "ar.#", "3"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "ar.243662212.ar_type", "IP4"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "ar.243662212.size", "16"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "ar.243662212.ip4", "172.16.100.110"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "ar.4282430103.ar_type", "IP4"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "ar.4282430103.size", "15"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "ar.4282430103.ip4", "172.16.100.170"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "ar.1816832807.ar_type", "IP4"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "ar.1816832807.size", "12"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "ar.1816832807.ip4", "172.16.100.130"),
 					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "hold_ips.#", "2"),
 					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "hold_ips.0", "172.16.100.112"),
 					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "hold_ips.1", "172.16.100.131"),
@@ -76,17 +79,18 @@ func TestAccVirtualNetwork(t *testing.T) {
 					resource.TestCheckResourceAttrSet("opennebula_virtual_network.test", "gid"),
 					resource.TestCheckResourceAttrSet("opennebula_virtual_network.test", "uname"),
 					resource.TestCheckResourceAttrSet("opennebula_virtual_network.test", "gname"),
-					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "ar.#", "3"),
-					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "ar.0.ar_type", "IP4"),
-					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "ar.0.size", "16"),
-					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "ar.0.ip4", "172.16.100.110"),
-					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "ar.0.mac", "02:01:ac:10:64:6e"),
-					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "ar.1.ar_type", "IP4"),
-					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "ar.1.size", "13"),
-					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "ar.1.ip4", "172.16.100.140"),
-					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "ar.2.ar_type", "IP6"),
-					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "ar.2.size", "2"),
-					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "ar.2.ip6", "2001:db8:0:85a3::ac1f:8001"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "ar.#", "4"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "ar.4282430103.ar_type", "IP4"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "ar.4282430103.size", "15"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "ar.4282430103.ip4", "172.16.100.170"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "ar.2475302130.ar_type", "IP4"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "ar.2475302130.size", "17"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "ar.2475302130.ip4", "172.16.100.110"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "ar.1095814213.ar_type", "IP4"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "ar.1095814213.size", "13"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "ar.1095814213.ip4", "172.16.100.140"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "ar.3729916233.ar_type", "IP6"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "ar.3729916233.size", "2"),
 					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "hold_ips.#", "2"),
 					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "hold_ips.0", "172.16.100.112"),
 					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "hold_ips.1", "172.16.100.141"),
@@ -232,6 +236,11 @@ resource "opennebula_virtual_network" "test" {
   }
   ar {
     ar_type = "IP4"
+    size    = 15
+    ip4     = "172.16.100.170"
+  }
+  ar {
+    ar_type = "IP4"
     size    = 12
     ip4     = "172.16.100.130"
   }
@@ -258,8 +267,12 @@ resource "opennebula_virtual_network" "test" {
   network_mask    = "255.255.0.0"
   ar {
     ar_type = "IP4"
-    size    = 16
-    mac     = "02:01:ac:10:64:6e"
+    size    = 15
+    ip4     = "172.16.100.170"
+  }
+  ar {
+    ar_type = "IP4"
+    size    = 17
     ip4     = "172.16.100.110"
   }
   ar {
@@ -270,7 +283,6 @@ resource "opennebula_virtual_network" "test" {
   ar {
     ar_type = "IP6"
     size    = 2
-    ip6     = "2001:db8:0:85a3::ac1f:8001"
   }
   hold_ips = ["172.16.100.112", "172.16.100.141"]
   security_groups = [0]
@@ -297,8 +309,12 @@ resource "opennebula_virtual_network" "test" {
   ar {
     ar_type = "IP4"
     size    = 16
-    mac     = "02:01:ac:10:64:6e"
     ip4     = "172.16.100.110"
+  }
+  ar {
+    ar_type = "IP4"
+    size    = 15
+    ip4     = "172.16.100.170"
   }
   ar {
     ar_type = "IP4"
@@ -308,9 +324,7 @@ resource "opennebula_virtual_network" "test" {
   ar {
     ar_type = "IP6"
     size    = 2
-    ip6     = "2001:db8:0:85a3::ac1f:8001"
   }
-  hold_ips = ["172.16.100.112", "172.16.100.141"]
   security_groups = [0]
   clusters = [0]
   permissions = "660"

--- a/website/docs/r/virtual_network.html.markdown
+++ b/website/docs/r/virtual_network.html.markdown
@@ -92,7 +92,7 @@ The following arguments are supported:
 * `ar_type` - (Optional) Address range type. Supported values: `IP4`, `IP6`, `IP6_STATIC`, `IP4_6` or `IP4_6_STATIC` or `ETHER`. Defaults to `IP4`.
 * `ip4` - (Optional) Starting IPv4 address of the range. Required if `ar_type` is `IP4` or `IP4_6`.
 * `ip6` - (Optional) Starting IPv6 address of the range. Required if `ar_type` is `IP6_STATIC` or `IP4_6_STATIC`.
-* `size - (Optional) Address range size.
+* `size` - (Required) Address range size.
 * `mac` - (Optional) Starting MAC Address of the range.
 * `global_prefix` - (Optional) Global prefix for `IP6` or `IP_4_6`.
 * `ula_prefix` - (Optional) ULA prefix for `IP6` or `IP_4_6`.
@@ -107,6 +107,14 @@ The following attribute are exported:
 * `gid` - Group ID which owns the virtual network.
 * `uname` - User Name whom owns the virtual network.
 * `gname` - Group Name which owns the virtual network.
+
+### Address range computed attributes
+
+* `id` - ID of the address range
+* `computed_ip6` - Starting IPv6 address of the range.
+* `computed_mac` - Starting MAC Address of the range.
+* `computed_global_prefix` - Global prefix for type `IP6` or `IP_4_6`.
+* `computed_ula_prefix` - ULA prefix for type `IP6` or `IP_4_6`.
 
 ## Import
 


### PR DESCRIPTION
Initial behavior to update the AR list was to: detach all ARs, then attach the ARs of the new list.

Rework a bit AR schema
- add `computed_` attributes counterpart instead of computed behavior (not for all attributes)
- change ar type from TypeList to Typeset to avoir ordering constraint

Add test cases, update changelog and documentation.
However, there is still some possible improvements: the `update_ar` method is not used to update the AR in place.