### PR TITLE
VM: optionally preserve nic ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 0.4.0 (Unreleased)
 
+FEATURES:
+* resources/opennebula_virtual_machine: Optionally preserve NIC ordering
+
 BUG FIXES:
 * resources/opennebula_virtual_network: fix type at read for reservation_vnet
 * resources/opennebula_virtual_network: reservation_vnet: Zero is a valid ID

--- a/opennebula/resource_opennebula_virtual_machine_test.go
+++ b/opennebula/resource_opennebula_virtual_machine_test.go
@@ -233,9 +233,34 @@ func TestAccVirtualMachineNICUpdate(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccVirtualMachineTemplateConfigMultipleNICs,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "name", "test-virtual_machine"),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "nic.#", "4"),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "nic.keep_nic_order", "false"),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "nic.0.computed_ip", "172.16.100.112"),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "nic.0.computed_ip", "172.16.100.132"),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "nic.0.computed_ip", "172.16.100.113"),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "nic.0.computed_ip", "172.16.100.133"),
+				),
+			},
+			{
+				Config: testAccVirtualMachineTemplateConfigMultipleNICsOrderedUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "name", "test-virtual_machine"),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "nic.#", "4"),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "nic.keep_nic_order", "true"),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "nic.0.computed_ip", "172.16.100.112"),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "nic.0.computed_ip", "172.16.100.134"),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "nic.0.computed_ip", "172.16.100.113"),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "nic.0.computed_ip", "172.16.100.133"),
+				),
+			},
+			{
 				Config: testAccVirtualMachineTemplateConfigNICDetached,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "name", "test-virtual_machine"),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "nic.keep_nic_order", "false"),
 					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "nic.#", "0"),
 				),
 			},
@@ -1085,6 +1110,109 @@ var testAccVirtualMachineTemplateConfigNICIPUpdate = testNICVNetResources + `
 	  nic {
 		  network_id = opennebula_virtual_network.network2.id
 		  ip = "172.16.100.112"
+	  }
+	
+	  timeout = 5
+}
+`
+
+var testAccVirtualMachineTemplateConfigMultipleNICs = testNICVNetResources + `
+
+  resource "opennebula_virtual_machine" "test" {
+	  name        = "test-virtual_machine"
+	  group       = "oneadmin"
+	  permissions = "642"
+	  memory = 128
+	  cpu = 0.1
+	
+	  context = {
+		NETWORK  = "YES"
+		SET_HOSTNAME = "$NAME"
+	  }
+	
+	  graphics {
+		type   = "VNC"
+		listen = "0.0.0.0"
+		keymap = "en-us"
+	  }
+	
+	  os {
+		arch = "x86_64"
+		boot = ""
+	  }
+	
+	  tags = {
+		env = "prod"
+		customer = "test"
+	  }
+
+	  nic {
+		network_id = opennebula_virtual_network.network2.id
+		ip         = "172.16.100.112"
+	  }
+	  nic {
+		network_id = opennebula_virtual_network.network1.id
+		ip         = "172.16.100.132"
+	  }
+	  nic {
+		network_id = opennebula_virtual_network.network2.id
+		ip         = "172.16.100.113"
+	  }
+	  nic {
+		network_id = opennebula_virtual_network.network1.id
+		ip         = "172.16.100.133"
+	  }
+	
+	  timeout = 5
+}
+`
+
+var testAccVirtualMachineTemplateConfigMultipleNICsOrderedUpdate = testNICVNetResources + `
+
+  resource "opennebula_virtual_machine" "test" {
+	  name        = "test-virtual_machine"
+	  group       = "oneadmin"
+	  permissions = "642"
+	  memory = 128
+	  cpu = 0.1
+	
+	  context = {
+		NETWORK  = "YES"
+		SET_HOSTNAME = "$NAME"
+	  }
+	
+	  graphics {
+		type   = "VNC"
+		listen = "0.0.0.0"
+		keymap = "en-us"
+	  }
+	
+	  os {
+		arch = "x86_64"
+		boot = ""
+	  }
+	
+	  tags = {
+		env = "prod"
+		customer = "test"
+	  }
+
+	  keep_nic_order = true
+	  nic {
+		network_id = opennebula_virtual_network.network2.id
+		ip         = "172.16.100.112"
+	  }
+	  nic {
+		network_id = opennebula_virtual_network.network1.id
+		ip         = "172.16.100.134"
+	  }
+	  nic {
+		network_id = opennebula_virtual_network.network2.id
+		ip         = "172.16.100.113"
+	  }
+	  nic {
+		network_id = opennebula_virtual_network.network1.id
+		ip         = "172.16.100.133"
 	  }
 	
 	  timeout = 5

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -85,6 +85,7 @@ The following arguments are supported:
 * `os` - (Optional) See [OS parameters](#os-parameters) below for details.
 * `disk` - (Optional) Can be specified multiple times to attach several disks. See [Disk parameters](#disk-parameters) below for details.
 * `nic` - (Optional) Can be specified multiple times to attach several NICs. See [Nic parameters](#nic-parameters) below for details.
+* `keep_nic_order` - (Optional) Indicates if the provider should keep NIC list ordering at update.
 * `vmgroup` - (Optional) See [VM group parameters](#vm-group-parameters) below for details. Changing this argument triggers a new resource.
 * `group` - (Optional) Name of the group which owns the virtual machine. Defaults to the caller primary group.
 * `tags` - (Optional) Virtual Machine tags (Key = Value).


### PR DESCRIPTION
Allow (optionally) to preserve VM nic ordering on update