### PR TITLE
F-159: add vm state deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ BUG FIXES:
 ENHANCEMENTS:
 * resources/opennebula_virtual_network: Enhance address range update
 * resources/opennebula_virtual_machine: enable context, os, graphics sections update
+* resources/opennebula_virtual_machine: Allow VM deletion from other states than RUNNING
 
 ## 0.3.0 (December 17, 2020)
 

--- a/opennebula/resource_opennebula_virtual_machine.go
+++ b/opennebula/resource_opennebula_virtual_machine.go
@@ -21,7 +21,7 @@ var (
 	vmDiskUpdateReadyStates = []string{"RUNNING", "POWEROFF"}
 	vmDiskResizeReadyStates = []string{"RUNNING", "POWEROFF", "UNDEPLOYED"}
 	vmNICUpdateReadyStates  = vmDiskUpdateReadyStates
-	vmDeleteReadyStates     = []string{"RUNNING", "HOLD"}
+	vmDeleteReadyStates     = []string{"RUNNING", "HOLD", "POWEROFF", "STOPPED", "UNDEPLOYED", "SUSPENDED"}
 )
 
 type flattenVMPart func(d *schema.ResourceData, vmTemplate *vm.Template) error
@@ -1435,7 +1435,7 @@ func waitForVMState(vmc *goca.VMController, timeout int, states ...string) (inte
 
 			switch vmState {
 
-			case vm.Done, vm.Hold:
+			case vm.Done, vm.Hold, vm.Suspended, vm.Stopped, vm.Poweroff, vm.Undeployed:
 				return vmInfos, vmState.String(), nil
 			case vm.Active:
 				switch vmLcmState {


### PR DESCRIPTION
Allow a VM to be deleted in these states: RUNNING, POWEROFF, STOPPED, UNDEPLOYED, SUSPENDED

[See OpenNebula 5.12 VM states references](https://docs.opennebula.io/5.12/operation/references/vm_states.html#vm-states)