### PR TITLE
B-176: vmgroup template: conditional role reading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ BUG FIXES:
 * resources/opennebula_group: Fix crash on quota datas reading
 * resources/opennebula_virtual_machine: Fix several NICs attached to the same network
 * resources/opennebula_security_group: fix rule conversion from struct to config
+* resources/opennebula_virtual_machine_group: make `role` reading conditional
 
 ENHANCEMENTS:
 * resources/opennebula_virtual_network: Enhance address range update

--- a/opennebula/resource_opennebula_template_vm_group.go
+++ b/opennebula/resource_opennebula_template_vm_group.go
@@ -257,9 +257,12 @@ func resourceOpennebulaVMGroupRead(d *schema.ResourceData, meta interface{}) err
 	d.Set("permissions", permissionsUnixString(*vmg.Permissions))
 
 	// Get Human readable vmg information
-	err = flattenVMGroupRoles(d, vmg.Roles)
-	if err != nil {
-		return err
+	_, ok := d.GetOk("roles")
+	if ok {
+		err = flattenVMGroupRoles(d, vmg.Roles)
+		if err != nil {
+			return err
+		}
 	}
 
 	err = flattenVMGroupTags(d, &vmg.Template)


### PR DESCRIPTION
The vmgroup_template data source is not usable for now, the Read method of the resource try to set role field, but there is no role field in the data source.
In order to not add role field to the data source and keep it simple, I made the role reading conditional: this field is required for the resource so it won't change the resource behavior, this will only impact the data source