### PR TITLE
Add 'on_disk_change' property to opennebula_virtual_machine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ ENHANCEMENTS:
 * data/opennebula_virtual_data_center: make `name` optional and add `tags` filtering
 * data/opennebula_virtual_network: make `name` optional and enable `tags` filtering
 
+FEATURES:
+
+* resources/opennebula_virtual_machine: Add 'on_disk_change' property to opennebula_virtual_machine
+
 DEPRECATION:
 
 * data/opennebula_group: deprecate `quotas` and remove `users`

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -51,6 +51,8 @@ resource "opennebula_virtual_machine" "demo" {
     driver   = "qcow2"
   }
 
+  on_disk_change = "RECREATE"
+
   nic {
     model           = "virtio"
     network_id      = var.vnetid
@@ -97,6 +99,7 @@ The following arguments are supported:
 * `tags` - (Optional) Virtual Machine tags (Key = Value).
 * `timeout` - (Optional) Timeout (in Minutes) for VM availability. Defaults to 3 minutes.
 * `lock` - (Optional) Lock the VM with a specific lock level. Supported values: `USE`, `MANAGE`, `ADMIN`, `ALL` or `UNLOCK`.
+* `on_disk_change` - (Optional) Select the behavior for changing disk images. Supported values: `RECREATE` or `SWAP` (default). `RECREATE` forces recreation of the vm and `SWAP` adopts the standard behavior of hot-swapping the disks. NOTE: This property does not affect the behavior of adding new disks.
 
 ### Graphics parameters
 


### PR DESCRIPTION
Add a property called 'on_disk_change' to the virtual machine resource;

```
  resource "opennebula_virtual_machine" "test_vm" {
     count       = 1
     name        = "test-vm"
     permissions = "660"
     cpu        = 1
     vcpu = 1
     memory     = 1024

     ...

     on_disk_change = "recreate"
  }
```

on_disk_change (if the disks image id has changed) can have three different values;

"recreate" - recreate the vm (call ForceNew)
"swap" - just swap the disk as normal

This pull request is in response to https://github.com/OpenNebula/terraform-provider-opennebula/issues/156