### PR TITLE
B-190: group: filter users field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ ENHANCEMENTS:
 * resources/opennebula_image: Enable description update
 * resources/opennebula_virtual_machine: Enable volatile disks
 
+DEPRECATION:
+* resources/opennebula_group: deprecate `users` to move group membership management on user resource side
+
 ## 0.3.0 (December 17, 2020)
 
 FEATURES:

--- a/opennebula/data_opennebula_group.go
+++ b/opennebula/data_opennebula_group.go
@@ -21,6 +21,7 @@ func dataOpennebulaGroup() *schema.Resource {
 				Elem: &schema.Schema{
 					Type: schema.TypeInt,
 				},
+				Deprecated: "use user data source for group membership instead.",
 			},
 			"admins": {
 				Type:        schema.TypeList,

--- a/opennebula/resource_opennebula_group_test.go
+++ b/opennebula/resource_opennebula_group_test.go
@@ -2,10 +2,11 @@ package opennebula
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"strconv"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 
 	"github.com/OpenNebula/one/src/oca/go/src/goca"
 )
@@ -51,6 +52,13 @@ func TestAccGroup(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccGroupWithUser,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("opennebula_user.user", "name", "iamuser"),
+					resource.TestCheckResourceAttrSet("opennebula_user.user", "primary_group"),
+				),
+			},
+			{
 				Config: testAccGroupLigh,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("opennebula_group.group2", "name", "noquotas"),
@@ -78,6 +86,15 @@ func testAccCheckGroupDestroy(s *terraform.State) error {
 
 	return nil
 }
+
+var testAccGroupUser = `
+resource "opennebula_user" "user" {
+	name          = "iamuser"
+	password      = "password"
+	auth_driver   = "core"
+	primary_group = opennebula_group.group.id
+  }
+`
 
 var testAccGroupConfigBasic = `
 resource "opennebula_group" "group" {
@@ -130,6 +147,8 @@ resource "opennebula_group" "group" {
     }
 }
 `
+
+var testAccGroupWithUser = testAccGroupConfigUpdate + testAccGroupUser
 
 var testAccGroupLigh = `
 resource "opennebula_group" "group" {

--- a/website/docs/d/group.html.markdown
+++ b/website/docs/d/group.html.markdown
@@ -26,7 +26,7 @@ data "opennebula_group" "ExistingGroup" {
 
 The following attribute is exported:
 * `id` - ID of the group.
-* `users` - List of User IDs part of the group.
+* `users` - (Deprecated): List of User IDs part of the group. Use groupe membership management through user resource instead.
 * `admins` - List of Administrator user IDs part of the group.
 * `quotas` - Quotas configured for the group.
 


### PR DESCRIPTION
Deprecate `users` field from group resource to move group membership management only on user resource side.
The management code of the `users` field has been modified in order to fix the problem. It still can be used to add users in a group, but it is no more computed and will filter only configured users at read step.