### PR TITLE
B #195: Fix service_template diffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 0.4.1 (Unreleased)
 
+BUG FIXES:
+* resources/opennebula_service_template: Fix `template` diff method to perform deep equal check over `ServiceTemplate` struct instead of binary file diff.
+
 ## 0.4.0 (January 20th, 2022)
 
 */!\ DISCALAIMER:*

--- a/opennebula/resource_opennebula_service_template.go
+++ b/opennebula/resource_opennebula_service_template.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"reflect"
 	"strconv"
 	"strings"
 
@@ -36,6 +37,23 @@ func resourceOpennebulaServiceTemplate() *schema.Resource {
 				Required:    true,
 				ForceNew:    true,
 				Description: "Service Template body in json format",
+				// Check JSON structure diffs, not binary diffs
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					old_template := &srv_tmpl.ServiceTemplate{}
+					new_template := &srv_tmpl.ServiceTemplate{}
+
+					err := json.Unmarshal([]byte(old), &old_template)
+					if err != nil {
+						return false
+					}
+
+					err = json.Unmarshal([]byte(new), &new_template)
+					if err != nil {
+						return false
+					}
+
+					return reflect.DeepEqual(old_template, new_template)
+				},
 			},
 			"permissions": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
Fix `template` diff method to perform deep equal check over
`ServiceTemplate` struct instead of binary file diff