### PR TITLE
B #215: fix vnet AR add crash

### DIFF
--- a/opennebula/resource_opennebula_virtual_network.go
+++ b/opennebula/resource_opennebula_virtual_network.go
@@ -1075,23 +1075,6 @@ func resourceOpennebulaVirtualNetworkUpdate(d *schema.ResourceData, meta interfa
 			"prefix_length",
 		)
 
-		// reorder arToAdd list according to new list order
-		newARToAdd := make([]interface{}, len(ARToAdd))
-
-		i := 0
-		for _, newARIf := range newARsCfg {
-			newAR := newARIf.(map[string]interface{})
-
-			for _, ARToAddIf := range ARToAdd {
-				AR := ARToAddIf.(map[string]interface{})
-
-				if (AR["ip4"] == newAR["ip4"] || AR["ip6"] == newAR["ip6"]) && AR["size"] == newAR["size"] {
-					newARToAdd[i] = AR
-					i++
-				}
-			}
-		}
-
 		// remove ARs
 		for _, ARIf := range ARToRem {
 			ARConfig := ARIf.(map[string]interface{})
@@ -1108,7 +1091,7 @@ func resourceOpennebulaVirtualNetworkUpdate(d *schema.ResourceData, meta interfa
 		}
 
 		// Add new ARs
-		for _, ARIf := range newARToAdd {
+		for _, ARIf := range ARToAdd {
 			ARConfig := ARIf.(map[string]interface{})
 
 			ARTemplateStr := generateAR(ARConfig).String()


### PR DESCRIPTION
In AR code management of the VNet resource I added some code (in #141) to enforce the order in which the AR are attached.
It's probably a mistake due to the fact that the type of the AR in terraform schema was initially Typelist (the orders of the elements matters with this data type), which I changed to Typeset later.
It's this piece of code that make the provider crash.
In this PR just remove this piece of code, it's faulty and not needed anymore.

To explained how the bug occured, this piece of code:
`if (AR["ip4"] == newAR["ip4"] || AR["ip6"] == newAR["ip6"]) && AR["size"] == newAR["size"] {`
is more often true that it should.
For instance in this case: if we have several `ip4` ARs with the same `size`, `ip6` field will be empty for all theses AR, then this test pass (all ip4 AR with same size are equal) and an indexing problem occur and this lead to a crash

close #215 