### PR TITLE
Optimize updates on cpumodel, cpu, vcpu and memory

### DIFF
--- a/opennebula/resource_opennebula_template.go
+++ b/opennebula/resource_opennebula_template.go
@@ -460,7 +460,7 @@ func resourceOpennebulaTemplateUpdate(d *schema.ResourceData, meta interface{}) 
 	update := false
 	deleteElements := false
 
-	attributeKeys := []string{"raw", "sched_requirements", "sched_ds_requirements", "description", "user_inputs"}
+	attributeKeys := []string{"raw", "sched_requirements", "sched_ds_requirements", "description", "user_inputs", "cpu", "vcpu", "memory", "cpumodel"}
 	for _, key := range attributeKeys {
 		if d.HasChange(key) {
 			update = true
@@ -520,6 +520,37 @@ func resourceOpennebulaTemplateUpdate(d *schema.ResourceData, meta interface{}) 
 		}
 	}
 
+	if d.HasChange("cpumodel") {
+		newTpl.Del("CPU_MODEL")
+		cpumodel := d.Get("cpumodel").([]interface{})
+		if len(cpumodel) > 0 {
+			for i := 0; i < len(cpumodel); i++ {
+				cpumodelconfig := cpumodel[i].(map[string]interface{})
+				newTpl.CPUModel(cpumodelconfig["model"].(string))
+			}
+		}
+	}
+	if d.HasChange("cpu") {
+		cpu := d.Get("cpu").(float64)
+		if cpu > 0 {
+			update = true
+			newTpl.CPU(cpu)
+		}
+	}
+	if d.HasChange("vcpu") {
+		vcpu := d.Get("vcpu").(int)
+		if vcpu > 0 {
+			update = true
+			newTpl.VCPU(vcpu)
+		}
+	}
+	if d.HasChange("memory") {
+		memory := d.Get("memory").(int)
+		if memory > 0 {
+			update = true
+			newTpl.Memory(memory)
+		}
+	}
 	if d.HasChange("user_inputs") {
 		newTpl.Del("USER_INPUTS")
 

--- a/opennebula/resource_opennebula_template_test.go
+++ b/opennebula/resource_opennebula_template_test.go
@@ -100,6 +100,7 @@ func TestAccTemplate(t *testing.T) {
 					resource.TestCheckResourceAttr("opennebula_template.template", "tags.env", "dev"),
 					resource.TestCheckResourceAttr("opennebula_template.template", "tags.customer", "test"),
 					resource.TestCheckResourceAttr("opennebula_template.template", "tags.version", "2"),
+					resource.TestCheckNoResourceAttr("opennebula_template.template", "cpumodel.#"),
 					resource.TestCheckResourceAttrSet("opennebula_template.template", "uid"),
 					resource.TestCheckResourceAttrSet("opennebula_template.template", "gid"),
 					resource.TestCheckResourceAttrSet("opennebula_template.template", "uname"),


### PR DESCRIPTION
Cpumode, cpu, vcpu and Memory Updates are not correctly updated. 


e.g. 
```
resource "opennebula_template" "template" {
  name = "terra-tpl-cpumodel"
  permissions = "660"
  group = "oneadmin"
  cpu = "0.5"
  vcpu = "1"
  memory = "512"

  context = {
    dns_hostname = "yes"
    network = "YES"
  }

  graphics {
    keymap = "en-us"
    listen = "0.0.0.0"
    type = "VNC"
  }

  cpumodel {
    model = "host-passthrough"
  }

  os {
    arch = "x86_64"
        boot = ""
  }

  tags = {
    env = "prod"
    customer = "test"
  }
}
```

to: 
```
resource "opennebula_template" "template" {
  name = "terratplupdate"
  permissions = "642"
  group = "oneadmin"

  cpu = "1"
  vcpu = "1"
  memory = "768"

  context = {
	dns_hostname = "yes"
	network = "YES"
  }

  graphics {
	keymap = "en-us"
	listen = "0.0.0.0"
	type = "VNC"
  }

  os {
	arch = "x86_64"
	boot = ""
  }

  tags = {
    env = "dev"
    customer = "test"
    version = "2"
  }
}
```

results in leaving cpu, memory, vpu and cpumodel untouched. 


Found in
#211 