### PR TITLE
B-220: template: fix template update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ BUG FIXES:
 
 * resources/opennebula_virtual_machine: fix description duplication
 * resources/opennebula_template: check fields at read
+* resources/opennebula_template: fix template update
 
 ## 0.4.1 (February 15th, 2022)
 

--- a/opennebula/resource_opennebula_template.go
+++ b/opennebula/resource_opennebula_template.go
@@ -500,8 +500,10 @@ func resourceOpennebulaTemplateUpdate(d *schema.ResourceData, meta interface{}) 
 
 	if d.HasChange("sched_requirements") {
 		schedRequirements := d.Get("sched_requirements").(string)
+
 		if len(schedRequirements) > 0 {
-			newTpl.Placement(vmk.SchedRequirements, schedRequirements)
+			escapedValue := strings.ReplaceAll(schedRequirements, "\"", "\\\"")
+			newTpl.Placement(vmk.SchedRequirements, escapedValue)
 		} else {
 			newTpl.Del(string(vmk.SchedRequirements))
 		}
@@ -509,11 +511,13 @@ func resourceOpennebulaTemplateUpdate(d *schema.ResourceData, meta interface{}) 
 	}
 
 	if d.HasChange("sched_ds_requirements") {
-		schedRequirements := d.Get("sched_ds_requirements").(string)
-		if len(schedRequirements) > 0 {
-			newTpl.Placement(vmk.SchedRequirements, schedRequirements)
+		schedDSRequirements := d.Get("sched_ds_requirements").(string)
+
+		if len(schedDSRequirements) > 0 {
+			escapedValue := strings.ReplaceAll(schedDSRequirements, "\"", "\\\"")
+			newTpl.Placement(vmk.SchedDSRequirements, escapedValue)
 		} else {
-			newTpl.Del(string(vmk.SchedRequirements))
+			newTpl.Del(string(vmk.SchedDSRequirements))
 		}
 		update = true
 	}

--- a/opennebula/resource_opennebula_template_test.go
+++ b/opennebula/resource_opennebula_template_test.go
@@ -38,7 +38,7 @@ func TestAccTemplate(t *testing.T) {
 					resource.TestCheckResourceAttr("opennebula_template.template", "sched_requirements", "FREE_CPU > 50"),
 					resource.TestCheckResourceAttr("opennebula_template.template", "user_inputs.%", "1"),
 					resource.TestCheckResourceAttr("opennebula_template.template", "user_inputs.BLOG_TITLE", "M|text|Blog Title"),
-					resource.TestCheckResourceAttr("opennebula_template.template", "description", "VM created for provider acceptance tests"),
+					resource.TestCheckResourceAttr("opennebula_template.template", "description", "Template created for provider acceptance tests"),
 					resource.TestCheckResourceAttrSet("opennebula_template.template", "uid"),
 					resource.TestCheckResourceAttrSet("opennebula_template.template", "gid"),
 					resource.TestCheckResourceAttrSet("opennebula_template.template", "uname"),
@@ -70,6 +70,8 @@ func TestAccTemplate(t *testing.T) {
 					resource.TestCheckResourceAttr("opennebula_template.template", "tags.%", "2"),
 					resource.TestCheckResourceAttr("opennebula_template.template", "tags.env", "prod"),
 					resource.TestCheckResourceAttr("opennebula_template.template", "tags.customer", "test"),
+					resource.TestCheckResourceAttr("opennebula_template.template", "sched_requirements", "FREE_CPU > 50"),
+					resource.TestCheckResourceAttr("opennebula_template.template", "description", "Template created for provider acceptance tests"),
 					resource.TestCheckResourceAttrSet("opennebula_template.template", "uid"),
 					resource.TestCheckResourceAttrSet("opennebula_template.template", "gid"),
 					resource.TestCheckResourceAttrSet("opennebula_template.template", "uname"),
@@ -100,6 +102,38 @@ func TestAccTemplate(t *testing.T) {
 					resource.TestCheckResourceAttr("opennebula_template.template", "tags.env", "dev"),
 					resource.TestCheckResourceAttr("opennebula_template.template", "tags.customer", "test"),
 					resource.TestCheckResourceAttr("opennebula_template.template", "tags.version", "2"),
+					resource.TestCheckResourceAttr("opennebula_template.template", "sched_requirements", "CLUSTER_ID!=\\\"123\\\""),
+					resource.TestCheckResourceAttr("opennebula_template.template", "description", "Template created for provider acceptance tests - updated"),
+					resource.TestCheckResourceAttrSet("opennebula_template.template", "uid"),
+					resource.TestCheckResourceAttrSet("opennebula_template.template", "gid"),
+					resource.TestCheckResourceAttrSet("opennebula_template.template", "uname"),
+					resource.TestCheckResourceAttrSet("opennebula_template.template", "gname"),
+					testAccCheckTemplatePermissions(&shared.Permissions{
+						OwnerU: 1,
+						OwnerM: 1,
+						GroupU: 1,
+						OtherM: 1,
+					}),
+				),
+			},
+			{
+				Config: testAccTemplateConfigDelete,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("opennebula_template.template", "name", "terratplupdate"),
+					resource.TestCheckResourceAttr("opennebula_template.template", "permissions", "642"),
+					resource.TestCheckResourceAttr("opennebula_template.template", "group", "oneadmin"),
+					resource.TestCheckResourceAttr("opennebula_template.template", "cpu", "1"),
+					resource.TestCheckResourceAttr("opennebula_template.template", "graphics.#", "1"),
+					resource.TestCheckResourceAttr("opennebula_template.template", "graphics.0.keymap", "en-us"),
+					resource.TestCheckResourceAttr("opennebula_template.template", "graphics.0.listen", "0.0.0.0"),
+					resource.TestCheckResourceAttr("opennebula_template.template", "graphics.0.type", "VNC"),
+					resource.TestCheckResourceAttr("opennebula_template.template", "os.#", "1"),
+					resource.TestCheckResourceAttr("opennebula_template.template", "os.0.arch", "x86_64"),
+					resource.TestCheckResourceAttr("opennebula_template.template", "os.0.boot", ""),
+					resource.TestCheckResourceAttr("opennebula_template.template", "tags.%", "2"),
+					resource.TestCheckResourceAttr("opennebula_template.template", "tags.env", "dev"),
+					resource.TestCheckResourceAttr("opennebula_template.template", "tags.customer", "test"),
+					resource.TestCheckNoResourceAttr("opennebula_template.template", "tags.version"),
 					resource.TestCheckResourceAttrSet("opennebula_template.template", "uid"),
 					resource.TestCheckResourceAttrSet("opennebula_template.template", "gid"),
 					resource.TestCheckResourceAttrSet("opennebula_template.template", "uname"),
@@ -180,7 +214,7 @@ resource "opennebula_template" "template" {
   cpu = "0.5"
   vcpu = "1"
   memory = "512"
-  description = "VM created for provider acceptance tests"
+  description = "Template created for provider acceptance tests"
 
   context = {
     dns_hostname = "yes"
@@ -220,6 +254,7 @@ resource "opennebula_template" "template" {
   cpu = "0.5"
   vcpu = "1"
   memory = "512"
+  description = "Template created for provider acceptance tests"
 
   context = {
     dns_hostname = "yes"
@@ -245,10 +280,51 @@ resource "opennebula_template" "template" {
     env = "prod"
     customer = "test"
   }
+
+  sched_requirements = "FREE_CPU > 50"
+
 }
 `
 
 var testAccTemplateConfigUpdate = `
+resource "opennebula_template" "template" {
+  name = "terratplupdate"
+  permissions = "642"
+  group = "oneadmin"
+  description = "Template created for provider acceptance tests - updated"
+
+  cpu = "1"
+  vcpu = "1"
+  memory = "768"
+
+  context = {
+	dns_hostname = "yes"
+	network = "YES"
+  }
+
+  graphics {
+	keymap = "en-us"
+	listen = "0.0.0.0"
+	type = "VNC"
+  }
+
+  os {
+	arch = "x86_64"
+	boot = ""
+  }
+
+  tags = {
+    env = "dev"
+    customer = "test"
+    version = "2"
+  }
+
+  sched_requirements = "CLUSTER_ID!=\\\"123\\\""
+
+}
+`
+
+var testAccTemplateConfigDelete = `
 resource "opennebula_template" "template" {
   name = "terratplupdate"
   permissions = "642"
@@ -277,7 +353,6 @@ resource "opennebula_template" "template" {
   tags = {
     env = "dev"
     customer = "test"
-    version = "2"
   }
 }
 `

--- a/opennebula/resource_opennebula_virtual_machine.go
+++ b/opennebula/resource_opennebula_virtual_machine.go
@@ -1035,8 +1035,10 @@ func resourceOpennebulaVirtualMachineUpdate(d *schema.ResourceData, meta interfa
 
 	if d.HasChange("sched_requirements") {
 		schedRequirements := d.Get("sched_requirements").(string)
+
 		if len(schedRequirements) > 0 {
-			tpl.Placement(vmk.SchedRequirements, schedRequirements)
+			escapedValue := strings.ReplaceAll(schedRequirements, "\"", "\\\"")
+			tpl.Placement(vmk.SchedRequirements, escapedValue)
 		} else {
 			tpl.Del(string(vmk.SchedRequirements))
 		}
@@ -1045,8 +1047,10 @@ func resourceOpennebulaVirtualMachineUpdate(d *schema.ResourceData, meta interfa
 
 	if d.HasChange("sched_ds_requirements") {
 		schedDSRequirements := d.Get("sched_ds_requirements").(string)
+
 		if len(schedDSRequirements) > 0 {
-			tpl.Placement(vmk.SchedDSRequirements, schedDSRequirements)
+			escapedValue := strings.ReplaceAll(schedDSRequirements, "\"", "\\\"")
+			tpl.Placement(vmk.SchedDSRequirements, escapedValue)
 		} else {
 			tpl.Del(string(vmk.SchedDSRequirements))
 		}

--- a/opennebula/resource_opennebula_virtual_machine.go
+++ b/opennebula/resource_opennebula_virtual_machine.go
@@ -518,7 +518,12 @@ func resourceOpennebulaVirtualMachineReadCustom(d *schema.ResourceData, meta int
 		return err
 	}
 
-	err = flattenTemplate(d, &vm.Template, false)
+	err = flattenTemplate(d, &vm.Template)
+	if err != nil {
+		return err
+	}
+
+	err = flattenUserTemplate(d, &vm.UserTemplate.Template)
 	if err != nil {
 		return err
 	}

--- a/opennebula/shared_schemas.go
+++ b/opennebula/shared_schemas.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 
+	"github.com/OpenNebula/one/src/oca/go/src/goca/dynamic"
 	"github.com/OpenNebula/one/src/oca/go/src/goca/schemas/shared"
 	"github.com/OpenNebula/one/src/oca/go/src/goca/schemas/vm"
 	vmk "github.com/OpenNebula/one/src/oca/go/src/goca/schemas/vm/keys"
@@ -573,7 +574,7 @@ func flattenDisk(disk shared.Disk) map[string]interface{} {
 	}
 }
 
-func flattenTemplate(d *schema.ResourceData, vmTemplate *vm.Template, tplTags bool) error {
+func flattenTemplate(d *schema.ResourceData, vmTemplate *vm.Template) error {
 
 	var err error
 
@@ -656,23 +657,28 @@ func flattenTemplate(d *schema.ResourceData, vmTemplate *vm.Template, tplTags bo
 		}
 	}
 
-	if tplTags {
-		tags := make(map[string]interface{})
-		// Get only tags from userTemplate
-		if tagsInterface, ok := d.GetOk("tags"); ok {
-			for k, _ := range tagsInterface.(map[string]interface{}) {
-				tags[k], err = vmTemplate.GetStr(strings.ToUpper(k))
-				if err != nil {
-					return err
-				}
-			}
-		}
+	return nil
+}
 
-		if len(tags) > 0 {
-			err := d.Set("tags", tags)
+func flattenUserTemplate(d *schema.ResourceData, vmTemplate *dynamic.Template) error {
+
+	var err error
+
+	tags := make(map[string]interface{})
+	// Get only tags from userTemplate
+	if tagsInterface, ok := d.GetOk("tags"); ok {
+		for k, _ := range tagsInterface.(map[string]interface{}) {
+			tags[k], err = vmTemplate.GetStr(strings.ToUpper(k))
 			if err != nil {
 				return err
 			}
+		}
+	}
+
+	if len(tags) > 0 {
+		err := d.Set("tags", tags)
+		if err != nil {
+			return err
 		}
 	}
 

--- a/opennebula/shared_schemas.go
+++ b/opennebula/shared_schemas.go
@@ -499,14 +499,15 @@ func generateVMTemplate(d *schema.ResourceData, tpl *vm.Template) error {
 
 	schedReq, ok := d.GetOk("sched_requirements")
 	if ok {
-		schedReqStr := strings.Replace(schedReq.(string), "\"", "\\\"", 3)
+		schedReqStr := strings.ReplaceAll(schedReq.(string), "\"", "\\\"")
+
 		tpl.AddPair("SCHED_REQUIREMENTS", schedReqStr)
 
 	}
 
 	schedDSReq, ok := d.GetOk("sched_ds_requirements")
 	if ok {
-		schedDSReqStr := strings.Replace(schedDSReq.(string), "\"", "\\\"", 3)
+		schedDSReqStr := strings.ReplaceAll(schedDSReq.(string), "\"", "\\\"")
 		tpl.AddPair("SCHED_DS_REQUIREMENTS", schedDSReqStr)
 
 	}


### PR DESCRIPTION
The template resource has some faulty update code in `resourceOpennebulaTemplateUpdate`:
```
	if d.HasChange("tags") {
		tagsInterface := d.Get("tags").(map[string]interface{})
		for k, v := range tagsInterface {
			tpl.Template.Del(strings.ToUpper(k))
			tpl.Template.AddPair(strings.ToUpper(k), v.(string))
		}

		err = tc.Update(tpl.Template.String(), 1)
		if err != nil {
			return err
		}
	}
```
if a key is removed, the key won't be listed anymore in `tagsInterface`, then there will be no loop iteration for the key we want to remove.
In addition, I think that to remove a key there is no other way than use the "replace" behavior of the template update method.
Look at [XML-RPC API for details](https://docs.opennebula.io/5.12/integration/system_interfaces/api.html#one-template-update)

We need to do something similar that I did in VM template part using `GetChange` method in #206 
The goal is to detect when a key is added/removed/updated and adapt the behavior.

Close #220 