### PR TITLE
B-205: fix duplicate description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-## 0.4.1 (Unreleased)
+## 0.4.2 (Unreleased)
+
+BUG FIXES:
+
+* resources/opennebula_virtual_machine: fix description duplication
+
+## 0.4.1 (February 15th, 2022)
 
 BUG FIXES:
 

--- a/opennebula/resource_opennebula_virtual_machine.go
+++ b/opennebula/resource_opennebula_virtual_machine.go
@@ -1050,13 +1050,14 @@ func resourceOpennebulaVirtualMachineUpdate(d *schema.ResourceData, meta interfa
 
 	if d.HasChange("description") {
 
+		tpl.Del(string(vmk.Description))
+
 		description := d.Get("description").(string)
 
 		if len(description) > 0 {
 			tpl.Add(vmk.Description, description)
-		} else {
-			tpl.Del(string(vmk.Description))
 		}
+
 		update = true
 	}
 


### PR DESCRIPTION
PR #206 introduced a small error for description attribute which may lead to duplicate `DESCRIPTION` keys in VM template on cloud side