### PR TITLE
[resource][virtual network] fix clusters attribute documentation

### DIFF
--- a/website/docs/r/virtual_network.html.markdown
+++ b/website/docs/r/virtual_network.html.markdown
@@ -43,13 +43,11 @@ resource "opennebula_virtual_network" "vnet" {
     dns             = "172.16.100.1"
     gateway         = "172.16.100.1"
     security_groups = [ 0 ]
+    clusters        = [ 0 ]
     ar {
          ar_type = "IP4"
          size    = 16
          ip4     = "172.16.100.101"
-    }
-    clusters {
-        id = 0
     }
     tags = {
       environment = "dev"


### PR DESCRIPTION
website/docs/r/virtual_network.html.markdown: fix documentaion for clusters attribute which should be a TypeList but was a TypeSet in the example.