### PR TITLE
Add GitHub Action to mark stale issues and pull requests when inactive

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,18 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/stale@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: "This issue is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 5 days"
+          days-before-stale: 60
+          days-before-close: 5
+          remove-stale-when-updated: true


### PR DESCRIPTION
The Stale state can be bypassed by commenting or removing the Stale label.