### PR TITLE
[resource][virtual_machine/template]: add DEV_PREFIX, CACHE, DISCARD, IO attributes to DISK section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ BUG FIXES:
 * data/opennebula_virtual_network: MTU is optional (#284)
 * resources/opennebula_virtual_machine: fix multiline regression (#309)
 
+ENHANCEMENTS:
+
+* resources/opennebula_virtual_machine: add `dev_prefix`, `cache`, `discard` and `io` to `disk` (#291)
+
 ## 0.5.1 (July 4th, 2022)
 
 ENHANCEMENTS:

--- a/opennebula/resource_opennebula_virtual_machine.go
+++ b/opennebula/resource_opennebula_virtual_machine.go
@@ -171,6 +171,22 @@ func diskComputedVMFields() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Computed: true,
 		},
+		"computed_dev_prefix": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"computed_cache": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"computed_discard": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"computed_io": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
 	}
 }
 
@@ -632,6 +648,18 @@ func flattenVMDiskComputed(diskConfig map[string]interface{}, disk shared.Disk) 
 	if len(diskConfig["volatile_format"].(string)) > 0 {
 		diskMap["volatile_format"] = diskMap["computed_volatile_format"]
 	}
+	if len(diskConfig["dev_prefix"].(string)) > 0 {
+		diskMap["dev_prefix"] = diskMap["computed_dev_prefix"]
+	}
+	if len(diskConfig["cache"].(string)) > 0 {
+		diskMap["cache"] = diskMap["computed_cache"]
+	}
+	if len(diskConfig["discard"].(string)) > 0 {
+		diskMap["discard"] = diskMap["computed_discard"]
+	}
+	if len(diskConfig["io"].(string)) > 0 {
+		diskMap["io"] = diskMap["computed_io"]
+	}
 
 	return diskMap
 }
@@ -641,6 +669,10 @@ func flattenDiskComputed(disk shared.Disk) map[string]interface{} {
 	driver, _ := disk.Get(shared.Driver)
 	target, _ := disk.Get(shared.TargetDisk)
 	volatileFormat, _ := disk.Get("FORMAT")
+	dev_prefix, _ := disk.Get("DEV_PREFIX")
+	cache, _ := disk.Get("CACHE")
+	discard, _ := disk.Get("DISCARD")
+	io, _ := disk.Get("IO")
 	diskID, _ := disk.GetI(shared.DiskID)
 
 	return map[string]interface{}{
@@ -649,6 +681,10 @@ func flattenDiskComputed(disk shared.Disk) map[string]interface{} {
 		"computed_target":          target,
 		"computed_driver":          driver,
 		"computed_volatile_format": volatileFormat,
+		"computed_dev_prefix":      dev_prefix,
+		"computed_cache":           cache,
+		"computed_discard":         discard,
+		"computed_io":              io,
 	}
 }
 
@@ -680,12 +716,20 @@ func matchDisk(diskConfig map[string]interface{}, disk shared.Disk) bool {
 	size, _ := disk.GetI(shared.Size)
 	driver, _ := disk.Get(shared.Driver)
 	target, _ := disk.Get(shared.TargetDisk)
+	dev_prefix, _ := disk.Get("DEV_PREFIX")
+	cache, _ := disk.Get("CACHE")
+	discard, _ := disk.Get("DISCARD")
+	io, _ := disk.Get("IO")
 	volatileType, _ := disk.Get("TYPE")
 	volatileFormat, _ := disk.Get("FORMAT")
 
 	return emptyOrEqual(diskConfig["target"], target) &&
 		emptyOrEqual(diskConfig["size"], size) &&
 		emptyOrEqual(diskConfig["driver"], driver) &&
+		emptyOrEqual(diskConfig["dev_prefix"], dev_prefix) &&
+		emptyOrEqual(diskConfig["cache"], cache) &&
+		emptyOrEqual(diskConfig["discard"], discard) &&
+		emptyOrEqual(diskConfig["io"], io) &&
 		emptyOrEqual(diskConfig["volatile_type"], volatileType) &&
 		emptyOrEqual(diskConfig["volatile_format"], volatileFormat)
 }
@@ -696,12 +740,19 @@ func matchDiskComputed(diskConfig map[string]interface{}, disk shared.Disk) bool
 	driver, _ := disk.Get(shared.Driver)
 	target, _ := disk.Get(shared.TargetDisk)
 	format, _ := disk.Get("FORMAT")
+	dev_prefix, _ := disk.Get("DEV_PREFIX")
+	cache, _ := disk.Get("CACHE")
+	discard, _ := disk.Get("DISCARD")
+	io, _ := disk.Get("IO")
 
 	return (target == diskConfig["computed_target"].(string)) &&
 		(size == diskConfig["computed_size"].(int)) &&
 		(driver == diskConfig["computed_driver"].(string)) &&
-		(format == diskConfig["computed_volatile_format"].(string))
-
+		(format == diskConfig["computed_volatile_format"].(string)) &&
+		(dev_prefix == diskConfig["computed_dev_prefix"].(string)) &&
+		(cache == diskConfig["computed_cache"].(string)) &&
+		(discard == diskConfig["computed_discard"].(string)) &&
+		(io == diskConfig["computed_io"].(string))
 }
 
 // flattenVMDisk is similar to flattenDisk but deal with computed_* attributes
@@ -1618,6 +1669,10 @@ func updateDisk(ctx context.Context, d *schema.ResourceData, meta interface{}) e
 		"image_id",
 		"target",
 		"driver",
+		"dev_prefix",
+		"cache",
+		"discard",
+		"io",
 		"volatile_type",
 		"volatile_format")
 
@@ -1633,7 +1688,11 @@ func updateDisk(ctx context.Context, d *schema.ResourceData, meta interface{}) e
 			// if disk have the same attributes
 			if (disk["target"] == newDisk["target"]) &&
 				disk["size"] == newDisk["size"] &&
-				disk["driver"] == newDisk["driver"] {
+				disk["driver"] == newDisk["driver"] &&
+				disk["dev_prefix"] == newDisk["dev_prefix"] &&
+				disk["cache"] == newDisk["cache"] &&
+				disk["discard"] == newDisk["discard"] &&
+				disk["io"] == newDisk["io"] {
 
 				newDisktoAttach[i] = disk
 				i++
@@ -1711,6 +1770,10 @@ func updateDisk(ctx context.Context, d *schema.ResourceData, meta interface{}) e
 			if diskConfig["image_id"].(int) != cfg["image_id"].(int) ||
 				(len(diskConfig["target"].(string)) > 0 && diskConfig["target"] != cfg["computed_target"]) ||
 				(len(diskConfig["driver"].(string)) > 0 && diskConfig["driver"] != cfg["computed_driver"]) ||
+				(len(diskConfig["dev_prefix"].(string)) > 0 && diskConfig["dev_prefix"] != cfg["computed_dev_prefix"]) ||
+				(len(diskConfig["cache"].(string)) > 0 && diskConfig["cache"] != cfg["computed_cache"]) ||
+				(len(diskConfig["discard"].(string)) > 0 && diskConfig["discard"] != cfg["computed_discard"]) ||
+				(len(diskConfig["io"].(string)) > 0 && diskConfig["io"] != cfg["computed_io"]) ||
 				diskConfig["size"].(int) <= cfg["computed_size"].(int) {
 
 				continue
@@ -2126,6 +2189,10 @@ func resourceVMCustomizeDiff(ctx context.Context, diff *schema.ResourceDiff, v i
 				diff.ForceNew(fmt.Sprintf("disk.%d.image_id", i))
 				diff.ForceNew(fmt.Sprintf("disk.%d.target", i))
 				diff.ForceNew(fmt.Sprintf("disk.%d.driver", i))
+				diff.ForceNew(fmt.Sprintf("disk.%d.dev_prefix", i))
+				diff.ForceNew(fmt.Sprintf("disk.%d.cache", i))
+				diff.ForceNew(fmt.Sprintf("disk.%d.discard", i))
+				diff.ForceNew(fmt.Sprintf("disk.%d.io", i))
 			}
 		}
 	}

--- a/opennebula/shared_schemas.go
+++ b/opennebula/shared_schemas.go
@@ -209,6 +209,22 @@ func diskFields(customFields ...map[string]*schema.Schema) map[string]*schema.Sc
 			Type:     schema.TypeString,
 			Optional: true,
 		},
+		"dev_prefix": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"cache": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"discard": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"io": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
 		"driver": {
 			Type:     schema.TypeString,
 			Optional: true,
@@ -462,6 +478,14 @@ func makeDiskVector(diskConfig map[string]interface{}) *shared.Disk {
 			disk.Add(shared.Driver, v.(string))
 		case "size":
 			disk.Add(shared.Size, strconv.Itoa(v.(int)))
+		case "dev_prefix":
+			disk.Add("DEV_PREFIX", v.(string))
+		case "cache":
+			disk.Add("CACHE", v.(string))
+		case "discard":
+			disk.Add("DISCARD", v.(string))
+		case "io":
+			disk.Add("IO", v.(string))
 		case "volatile_type":
 			disk.Add("TYPE", v.(string))
 		case "volatile_format":
@@ -671,6 +695,10 @@ func flattenDisk(disk shared.Disk) map[string]interface{} {
 	}
 	driver, _ := disk.Get(shared.Driver)
 	target, _ := disk.Get(shared.TargetDisk)
+	dev_prefix, _ := disk.Get("DEV_PREFIX")
+	cache, _ := disk.Get("CACHE")
+	discard, _ := disk.Get("DISCARD")
+	io, _ := disk.Get("IO")
 	imageID, _ := disk.GetI(shared.ImageID)
 	volatileType, _ := disk.Get("TYPE")
 	volatileFormat, _ := disk.Get("FORMAT")
@@ -679,6 +707,10 @@ func flattenDisk(disk shared.Disk) map[string]interface{} {
 		"image_id":        imageID,
 		"size":            size,
 		"target":          target,
+		"dev_prefix":      dev_prefix,
+		"cache":           cache,
+		"discard":         discard,
+		"io":              io,
 		"driver":          driver,
 		"volatile_type":   volatileType,
 		"volatile_format": volatileFormat,

--- a/website/docs/r/template.html.markdown
+++ b/website/docs/r/template.html.markdown
@@ -135,6 +135,10 @@ The following arguments are supported:
 * `size` - (Optional) Size (in MB) of the image attached to the virtual machine. Not possible to change a cloned image size.
 * `target` - (Optional) Target name device on the virtual machine. Depends of the image `dev_prefix`.
 * `driver` - (Optional) OpenNebula image driver.
+* `dev_prefix` - (Optional) Prefix for the emulated device this image will be mounted at. For instance, attribute of the Image will be used.
+* `cache` - (Optional) Selects the cache mechanism for the disk. Values are default, none, writethrough, writeback, directsync and unsafe.
+* `discard` - (Optional) Controls what’s done with with trim commands to the disk, the values can be ignore or discard.
+* `io` - (Optional) Set IO policy. Values are threads, native.
 * `volatile_type` - (Optional) Type of the volatile disk: `swap` or `fs`. Type `swap` is not supported in vcenter. Conflicts with `image_id`.
 * `volatile_format` - (Optional) Format of the volatile disk: `raw` or `qcow2`. Conflicts with `image_id`.
 


### PR DESCRIPTION
I removed the default value (raw) for `volatile_format` because this attribute would be added any time when one wants to add any of the attributes. This then conflicts when there already is an `image_id`.