### PR TITLE
F-248: group template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ ENHANCEMENTS:
 * data/opennebula_virtual_data_center: make `name` optional and add `tags` filtering
 * data/opennebula_virtual_network: make `name` optional and enable `tags` filtering
 * resources/opennebula_virtual_machine: add `raw` as default value for `volatile_format`
+* resources/opennebula_group: add `sunstone` and `tags` sections
 
 FEATURES:
 
@@ -23,7 +24,7 @@ FEATURES:
 
 DEPRECATION:
 
-* data/opennebula_group: deprecate `quotas` and remove `users`
+* data/opennebula_group: deprecate `quotas`, `template`, remove `users`
 * data/opennebula_group: deprecate `delete_on_destruction` and set its default value to `true`
 * data/opennebula_template: deprecate `context`, `graphics` and `os`. Make `disk`, `nic` and `vmgroup` computed. Remove `template`
 * data/opennebula_user: deprecate `quotas` and `auth_driver`

--- a/opennebula/helpers.go
+++ b/opennebula/helpers.go
@@ -21,11 +21,6 @@ func inArray(val string, array []string) (index int) {
 	return -1
 }
 
-// appendTemplate add attribute and value to an existing string
-func appendTemplate(template, attribute, value string) string {
-	return fmt.Sprintf("%s\n%s = \"%s\"", template, attribute, value)
-}
-
 func ArrayToString(list []interface{}, delim string) string {
 	return strings.Trim(strings.Join(strings.Fields(fmt.Sprint(list)), delim), "[]")
 }

--- a/opennebula/resource_opennebula_group.go
+++ b/opennebula/resource_opennebula_group.go
@@ -1,13 +1,17 @@
 package opennebula
 
 import (
+	"encoding/xml"
 	"fmt"
 	"log"
 	"strconv"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 
 	"github.com/OpenNebula/one/src/oca/go/src/goca"
+	dyn "github.com/OpenNebula/one/src/oca/go/src/goca/dynamic"
+	"github.com/OpenNebula/one/src/oca/go/src/goca/parameters"
 )
 
 func resourceOpennebulaGroup() *schema.Resource {
@@ -27,9 +31,11 @@ func resourceOpennebulaGroup() *schema.Resource {
 				Description: "Name of the Group",
 			},
 			"template": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "Group template content, in OpenNebula XML or String format",
+				Type:          schema.TypeString,
+				Optional:      true,
+				Description:   "Group template content, in OpenNebula XML or String format",
+				Deprecated:    "use other schema sections",
+				ConflictsWith: []string{"sunstone", "tags"},
 			},
 			"delete_on_destruction": {
 				Type:        schema.TypeBool,
@@ -58,6 +64,41 @@ func resourceOpennebulaGroup() *schema.Resource {
 				Deprecated: "use opennebula_group_admins resource instead.",
 			},
 			"quotas": quotasSchema(),
+			"sunstone": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Description: "Allow users and group admins to access specific views",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"default_view": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Default Sunstone view for regular users",
+						},
+						"views": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "List of available views for regular users",
+						},
+						"group_admin_default_view": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Default Sunstone view for group admin users",
+						},
+						"group_admin_views": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "List of available views for the group admins",
+						},
+					},
+				},
+				ConflictsWith: []string{"template"},
+			},
+			"tags": func() *schema.Schema {
+				s := tagsSchema()
+				s.ConflictsWith = []string{"template"}
+				return s
+			}(),
 		},
 	}
 }
@@ -98,15 +139,6 @@ func resourceOpennebulaGroupCreate(d *schema.ResourceData, meta interface{}) err
 
 	gc := controller.Group(groupID)
 
-	// add template description
-	if d.Get("template") != "" {
-		// Erase previous template
-		err = gc.Update(d.Get("template").(string), 0)
-		if err != nil {
-			return err
-		}
-	}
-
 	// add users if list provided
 	if userids, ok := d.GetOk("users"); ok {
 		userlist := userids.([]interface{})
@@ -141,7 +173,67 @@ func resourceOpennebulaGroupCreate(d *schema.ResourceData, meta interface{}) err
 		}
 	}
 
+	// template management
+
+	// add template description
+	if d.Get("template") != "" {
+		// Erase previous template
+		err = gc.Update(d.Get("template").(string), 0)
+		if err != nil {
+			return err
+		}
+	}
+
+	tpl := dyn.NewTemplate()
+
+	sunstone := d.Get("sunstone").(*schema.Set).List()
+	if len(sunstone) > 0 {
+		sunstoneVec := makeSunstoneVec(sunstone[0].(map[string]interface{}))
+		tpl.Elements = append(tpl.Elements, sunstoneVec)
+	}
+
+	tagsInterface := d.Get("tags").(map[string]interface{})
+	for k, v := range tagsInterface {
+		tpl.AddPair(strings.ToUpper(k), v)
+	}
+
+	if len(tpl.Elements) > 0 {
+		err = gc.Update(tpl.String(), parameters.Merge)
+		if err != nil {
+			return err
+		}
+	}
+
 	return resourceOpennebulaGroupRead(d, meta)
+}
+
+func makeSunstoneVec(sunstoneConfig map[string]interface{}) *dyn.Vector {
+
+	vector := dyn.Vector{
+		XMLName: xml.Name{Local: "SUNSTONE"},
+	}
+
+	defaultView := sunstoneConfig["default_view"].(string)
+	if len(defaultView) > 0 {
+		vector.AddPair("DEFAULT_VIEW", defaultView)
+	}
+
+	views := sunstoneConfig["views"].(string)
+	if len(views) > 0 {
+		vector.AddPair("VIEWS", views)
+	}
+
+	groupAdminDefaultView := sunstoneConfig["group_admin_default_view"].(string)
+	if len(groupAdminDefaultView) > 0 {
+		vector.AddPair("GROUP_ADMIN_DEFAULT_VIEW", groupAdminDefaultView)
+	}
+
+	groupAdminViews := sunstoneConfig["group_admin_views"].(string)
+	if len(groupAdminViews) > 0 {
+		vector.AddPair("GROUP_ADMIN_VIEWS", groupAdminViews)
+	}
+
+	return &vector
 }
 
 func resourceOpennebulaGroupRead(d *schema.ResourceData, meta interface{}) error {
@@ -198,21 +290,77 @@ func resourceOpennebulaGroupRead(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 
-	return nil
-}
-
-func resourceOpennebulaGroupUpdate(d *schema.ResourceData, meta interface{}) error {
-	gc, err := getGroupController(d, meta)
+	err = flattenGroupTemplate(d, &group.Template)
 	if err != nil {
 		return err
 	}
 
-	if d.HasChange("template") {
-		// Erase previous template
-		err = gc.Update(d.Get("template").(string), 0)
+	return nil
+}
+
+func flattenGroupTemplate(d *schema.ResourceData, groupTpl *dyn.Template) error {
+
+	tags := make(map[string]interface{})
+	for i, _ := range groupTpl.Elements {
+
+		switch e := groupTpl.Elements[i].(type) {
+		case *dyn.Pair:
+
+			// Get only tags described in the configuration
+			if tagsInterface, ok := d.GetOk("tags"); ok {
+				var err error
+				for k, _ := range tagsInterface.(map[string]interface{}) {
+					tags[k], err = groupTpl.GetStr(strings.ToUpper(k))
+					if err != nil {
+						return err
+					}
+				}
+
+			}
+		case *dyn.Vector:
+			switch e.Key() {
+			case "SUNSTONE":
+				defaultView, _ := e.GetStr("DEFAULT_VIEW")
+				views, _ := e.GetStr("VIEWS")
+				groupAdminDefaultView, _ := e.GetStr("GROUP_ADMIN_DEFAULT_VIEW")
+				groupAdminViews, _ := e.GetStr("GROUP_ADMIN_VIEWS")
+
+				sunstoneConfig := []map[string]interface{}{
+					{
+						"default_view":             defaultView,
+						"views":                    views,
+						"group_admin_default_view": groupAdminDefaultView,
+						"group_admin_views":        groupAdminViews,
+					},
+				}
+
+				err := d.Set("sunstone", sunstoneConfig)
+				if err != nil {
+					return err
+				}
+			default:
+				log.Printf("[DEBUG] ignored: %s", e)
+			}
+
+		}
+
+	}
+
+	if len(tags) > 0 {
+		err := d.Set("tags", tags)
 		if err != nil {
 			return err
 		}
+	}
+
+	return nil
+}
+
+func resourceOpennebulaGroupUpdate(d *schema.ResourceData, meta interface{}) error {
+
+	gc, err := getGroupController(d, meta)
+	if err != nil {
+		return err
 	}
 
 	if d.HasChange("quotas") {
@@ -225,6 +373,67 @@ func resourceOpennebulaGroupUpdate(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return err
 			}
+		}
+	}
+
+	// template management
+
+	group, err := gc.Info(false)
+	if err != nil {
+		return err
+	}
+
+	if d.HasChange("template") {
+		// Erase previous template
+		err = gc.Update(d.Get("template").(string), 0)
+		if err != nil {
+			return err
+		}
+	}
+
+	update := false
+	newTpl := group.Template
+
+	if d.HasChange("sunstone") {
+		newTpl.Del("SUNSTONE")
+
+		sunstone := d.Get("sunstone").(*schema.Set).List()
+		if len(sunstone) > 0 {
+			sunstoneVec := makeSunstoneVec(sunstone[0].(map[string]interface{}))
+			newTpl.Elements = append(newTpl.Elements, sunstoneVec)
+		}
+
+		update = true
+	}
+
+	if d.HasChange("tags") {
+
+		oldTagsIf, newTagsIf := d.GetChange("tags")
+		oldTags := oldTagsIf.(map[string]interface{})
+		newTags := newTagsIf.(map[string]interface{})
+
+		// delete tags
+		for k, _ := range oldTags {
+			_, ok := newTags[k]
+			if ok {
+				continue
+			}
+			newTpl.Del(strings.ToUpper(k))
+		}
+
+		// add/update tags
+		for k, v := range newTags {
+			newTpl.Del(strings.ToUpper(k))
+			newTpl.AddPair(strings.ToUpper(k), v)
+		}
+
+		update = true
+	}
+
+	if update {
+		err = gc.Update(newTpl.String(), parameters.Replace)
+		if err != nil {
+			return err
 		}
 	}
 

--- a/opennebula/resource_opennebula_group_test.go
+++ b/opennebula/resource_opennebula_group_test.go
@@ -32,6 +32,13 @@ func TestAccGroup(t *testing.T) {
 					resource.TestCheckResourceAttr("opennebula_group.group", "quotas.4169128061.vm_quotas.#", "1"),
 					resource.TestCheckResourceAttr("opennebula_group.group", "quotas.4169128061.vm_quotas.2832483756.cpu", "4"),
 					resource.TestCheckResourceAttr("opennebula_group.group", "quotas.4169128061.vm_quotas.2832483756.memory", "8192"),
+					resource.TestCheckResourceAttr("opennebula_group.group", "sunstone.4128055932.default_view", "cloud"),
+					resource.TestCheckResourceAttr("opennebula_group.group", "sunstone.4128055932.group_admin_default_view", "groupadmin"),
+					resource.TestCheckResourceAttr("opennebula_group.group", "sunstone.4128055932.group_admin_views", "groupadmin"),
+					resource.TestCheckResourceAttr("opennebula_group.group", "sunstone.4128055932.views", "cloud"),
+					resource.TestCheckResourceAttr("opennebula_group.group", "tags.%", "2"),
+					resource.TestCheckResourceAttr("opennebula_group.group", "tags.testkey1", "testvalue1"),
+					resource.TestCheckResourceAttr("opennebula_group.group", "tags.testkey2", "testvalue2"),
 				),
 			},
 			{
@@ -49,6 +56,13 @@ func TestAccGroup(t *testing.T) {
 					resource.TestCheckResourceAttr("opennebula_group.group", "quotas.261273647.vm_quotas.#", "1"),
 					resource.TestCheckResourceAttr("opennebula_group.group", "quotas.261273647.vm_quotas.2832483756.cpu", "4"),
 					resource.TestCheckResourceAttr("opennebula_group.group", "quotas.261273647.vm_quotas.2832483756.memory", "8192"),
+					resource.TestCheckResourceAttr("opennebula_group.group", "sunstone.1904779058.default_view", "cloud"),
+					resource.TestCheckResourceAttr("opennebula_group.group", "sunstone.1904779058.group_admin_default_view", "groupadmin"),
+					resource.TestCheckResourceAttr("opennebula_group.group", "sunstone.1904779058.group_admin_views", "cloud"),
+					resource.TestCheckResourceAttr("opennebula_group.group", "sunstone.1904779058.views", "cloud"),
+					resource.TestCheckResourceAttr("opennebula_group.group", "tags.%", "2"),
+					resource.TestCheckResourceAttr("opennebula_group.group", "tags.testkey2", "testvalue2"),
+					resource.TestCheckResourceAttr("opennebula_group.group", "tags.testkey3", "testvalue3"),
 				),
 			},
 			{
@@ -56,6 +70,13 @@ func TestAccGroup(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("opennebula_user.user", "name", "iamuser"),
 					resource.TestCheckResourceAttrSet("opennebula_user.user", "primary_group"),
+					resource.TestCheckResourceAttr("opennebula_group.group", "sunstone.1904779058.default_view", "cloud"),
+					resource.TestCheckResourceAttr("opennebula_group.group", "sunstone.1904779058.group_admin_default_view", "groupadmin"),
+					resource.TestCheckResourceAttr("opennebula_group.group", "sunstone.1904779058.group_admin_views", "cloud"),
+					resource.TestCheckResourceAttr("opennebula_group.group", "sunstone.1904779058.views", "cloud"),
+					resource.TestCheckResourceAttr("opennebula_group.group", "tags.%", "2"),
+					resource.TestCheckResourceAttr("opennebula_group.group", "tags.testkey2", "testvalue2"),
+					resource.TestCheckResourceAttr("opennebula_group.group", "tags.testkey3", "testvalue3"),
 				),
 			},
 			{
@@ -70,6 +91,11 @@ func TestAccGroup(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("opennebula_group.group2", "name", "noquotas"),
 					resource.TestCheckResourceAttr("opennebula_group.group2", "delete_on_destruction", "true"),
+					resource.TestCheckResourceAttr("opennebula_group.group2", "sunstone.1904779058.default_view", "cloud"),
+					resource.TestCheckResourceAttr("opennebula_group.group2", "sunstone.1904779058.group_admin_default_view", "groupadmin"),
+					resource.TestCheckResourceAttr("opennebula_group.group2", "sunstone.1904779058.group_admin_views", "cloud"),
+					resource.TestCheckResourceAttr("opennebula_group.group2", "sunstone.1904779058.views", "cloud"),
+					resource.TestCheckResourceAttr("opennebula_group.group2", "tags.%", "0"),
 				),
 			},
 		},
@@ -105,15 +131,13 @@ resource "opennebula_user" "user" {
 
 var testAccGroupConfigBasic = `
 resource "opennebula_group" "group" {
-  name = "iamgroup"
-  template = <<EOF
-    SUNSTONE = [
-      DEFAULT_VIEW = "cloud",
-      GROUP_ADMIN_DEFAULT_VIEW = "groupadmin",
-      GROUP_ADMIN_VIEWS = "groupadmin",
-      VIEWS = "cloud"
-    ]
-    EOF
+    name = "iamgroup"
+    sunstone {
+      default_view = "cloud"
+      group_admin_default_view = "groupadmin"
+      group_admin_views = "groupadmin"
+      views = "cloud"
+	}
     delete_on_destruction = false
     quotas {
         datastore_quotas {
@@ -126,20 +150,22 @@ resource "opennebula_group" "group" {
             memory = 8192
         }
     }
+	tags = {
+		testkey1 = "testvalue1"
+		testkey2 = "testvalue2"
+	}
 }
 `
 
 var testAccGroupConfigUpdate = `
 resource "opennebula_group" "group" {
-  name = "iamgroup"
-  template = <<EOF
-    SUNSTONE = [
-      DEFAULT_VIEW = "cloud",
-      GROUP_ADMIN_DEFAULT_VIEW = "groupadmin",
-      GROUP_ADMIN_VIEWS = "cloud",
-      VIEWS = "cloud"
-    ]
-    EOF
+    name = "iamgroup"
+	sunstone {
+		default_view = "cloud"
+		group_admin_default_view = "groupadmin"
+		group_admin_views = "cloud"
+		views = "cloud"
+	}
     delete_on_destruction = true
     quotas {
         datastore_quotas {
@@ -152,6 +178,10 @@ resource "opennebula_group" "group" {
             memory = 8192
         }
     }
+	tags = {
+		testkey2 = "testvalue2"
+		testkey3 = "testvalue3"
+	}
 }
 `
 
@@ -168,15 +198,13 @@ resource "opennebula_group_admins" "admins" {
 
 var testAccGroupLigh = `
 resource "opennebula_group" "group" {
-  name = "iamgroup"
-  template = <<EOF
-    SUNSTONE = [
-      DEFAULT_VIEW = "cloud",
-      GROUP_ADMIN_DEFAULT_VIEW = "groupadmin",
-      GROUP_ADMIN_VIEWS = "cloud",
-      VIEWS = "cloud"
-    ]
-    EOF
+    name = "iamgroup"
+	sunstone {
+		default_view = "cloud"
+		group_admin_default_view = "groupadmin"
+		group_admin_views = "cloud"
+		views = "cloud"
+	}
     delete_on_destruction = true
     quotas {
         datastore_quotas {
@@ -192,15 +220,13 @@ resource "opennebula_group" "group" {
 }
 
 resource "opennebula_group" "group2" {
-  name = "noquotas"
-  template = <<EOF
-    SUNSTONE = [
-      DEFAULT_VIEW = "cloud",
-      GROUP_ADMIN_DEFAULT_VIEW = "groupadmin",
-      GROUP_ADMIN_VIEWS = "cloud",
-      VIEWS = "cloud"
-    ]
-    EOF
+    name = "noquotas"
+	sunstone {
+		default_view = "cloud"
+		group_admin_default_view = "groupadmin"
+		group_admin_views = "cloud"
+		views = "cloud"
+	}
     delete_on_destruction = true
 }
 `

--- a/website/docs/r/group.html.markdown
+++ b/website/docs/r/group.html.markdown
@@ -16,13 +16,8 @@ a new group is created. When destroyed, it is removed.
 ## Example Usage
 
 ```hcl
-data "template_file" "grptpl" {
-  template = file("group_template.txt")
-}
-
 resource "opennebula_group" "group" {
     name                  = "terraform"
-    template              = data.template_file.grptpl.rendered
     quotas {
         datastore_quotas {
             id     = 1
@@ -55,26 +50,17 @@ resource "opennebula_group" "group" {
 }
 ```
 
-with `group_template.txt` file with Sunstone information:
-
-```php
-SUNSTONE = [
-  DEFAULT_VIEW = "cloud",
-  GROUP_ADMIN_DEFAULT_VIEW = "groupadmin",
-  GROUP_ADMIN_VIEWS = "cloud,groupadmin",
-  VIEWS = "cloud"
-]
-```
-
 ## Argument Reference
 
 The following arguments are supported:
 
 * `name` - (Required) The name of the group.
-* `template` - (Required) Group template content in OpenNebula XML or String format. Used to provide SUSNTONE arguments.
+* `template` - (Deprecated) Group template content in OpenNebula XML or String format. Used to provide SUSNTONE arguments.
 * `delete_on_destruction` - (Deprecated) Flag to delete the group on destruction. Defaults to `true`. Use [Terraform lifecycle `prevent_destroy`](https://www.terraform.io/language/meta-arguments/lifecycle#prevent_destroy) instead.
 * `admins` - (Optional) List of Administrator user IDs part of the group.
 * `quotas` - (Optional) See [Quotas parameters](#quotas-parameters) below for details
+* `sunstone` - (Optional) Allow users and group admins to access specific views. See [Sunstone parameters](#sunstone-parameters) below for details
+* `tags` - (Optional) Group tags (Key = value)
 
 ### Quotas parameters
 
@@ -119,9 +105,17 @@ The following arguments are supported:
 * `running_vms` - (Optional) Number of Virtual Machines allowed in `RUNNING` state. Defaults to `default quota`.
 * `system_disk_size` - (Optional) Maximum disk global size (in MB) allowed on a `SYSTEM` datastore. Defaults to `default quota`.
 
+#### Sunstone parameters
+
+* `default_view` - (Optional) Default Sunstone view for regular users
+* `views` - (Optional) List of available views for regular users
+* `group_admin_default_view` - (Optional) Default Sunstone view for group admin users
+* `group_admin_views` - (Optional) List of available views for the group admins
+
 ## Attribute Reference
 
 The following attribute is exported:
+
 * `id` - ID of the group.
 
 ## Import


### PR DESCRIPTION
This PR deprecate the `template` attribute and to provide a replacement.
The goal is to manage group templates like it's done in other resources via some additional static sections and a dynamic `tags` section.

Close #248 