### PR TITLE
B-239: fix volatile disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ DEPRECATION:
 BUG FIXES:
 
 * resources/opennebula_security_group: read `name`
+* resources/opennebula_virtual_machine: fix volatile disk update adding `computed_volatile_format`
 
 ## 0.4.3 (March 23th, 2022)
 

--- a/opennebula/resource_opennebula_virtual_machine.go
+++ b/opennebula/resource_opennebula_virtual_machine.go
@@ -268,6 +268,10 @@ func diskComputedVMFields() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Computed: true,
 		},
+		"computed_volatile_format": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
 	}
 }
 
@@ -571,6 +575,9 @@ func flattenVMDiskComputed(diskConfig map[string]interface{}, disk shared.Disk) 
 	if len(diskConfig["driver"].(string)) > 0 {
 		diskMap["driver"] = diskMap["computed_driver"]
 	}
+	if len(diskConfig["volatile_format"].(string)) > 0 {
+		diskMap["volatile_format"] = diskMap["computed_volatile_format"]
+	}
 
 	return diskMap
 }
@@ -579,13 +586,15 @@ func flattenDiskComputed(disk shared.Disk) map[string]interface{} {
 	size, _ := disk.GetI(shared.Size)
 	driver, _ := disk.Get(shared.Driver)
 	target, _ := disk.Get(shared.TargetDisk)
+	volatileFormat, _ := disk.Get("FORMAT")
 	diskID, _ := disk.GetI(shared.DiskID)
 
 	return map[string]interface{}{
-		"disk_id":         diskID,
-		"computed_size":   size,
-		"computed_target": target,
-		"computed_driver": driver,
+		"disk_id":                  diskID,
+		"computed_size":            size,
+		"computed_target":          target,
+		"computed_driver":          driver,
+		"computed_volatile_format": volatileFormat,
 	}
 }
 
@@ -632,10 +641,12 @@ func matchDiskComputed(diskConfig map[string]interface{}, disk shared.Disk) bool
 	size, _ := disk.GetI(shared.Size)
 	driver, _ := disk.Get(shared.Driver)
 	target, _ := disk.Get(shared.TargetDisk)
+	format, _ := disk.Get("FORMAT")
 
 	return (target == diskConfig["computed_target"].(string)) &&
 		(size == diskConfig["computed_size"].(int)) &&
-		(driver == diskConfig["computed_driver"].(string))
+		(driver == diskConfig["computed_driver"].(string)) &&
+		(format == diskConfig["computed_volatile_format"].(string))
 
 }
 
@@ -686,9 +697,6 @@ diskLoop:
 				volatileType, _ := disk.Get("TYPE")
 				diskMap["volatile_type"] = volatileType
 			}
-
-			volatileFormat, _ := disk.Get("FORMAT")
-			diskMap["volatile_format"] = volatileFormat
 
 			diskList = append(diskList, diskMap)
 

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -170,7 +170,6 @@ The following attribute are exported:
 * `template_disk` - when `template_id` is used and the template define some disks, this contains the template disks description.
 * `template_nic` - when `template_id` is used and the template define some NICs, this contains the template NICs description.
 
-
 ### Template NIC
 
 * `network_id` - ID of the image attached to the virtual machine.
@@ -182,7 +181,6 @@ The following attribute are exported:
 * `computed_virtio_queues` - Virtio multi-queue size.
 * `computed_physical_device` - Physical device hosting the virtual network.
 * `computed_security_groups` - List of security group IDs to use on the virtual.
-
 
 ### Template disk
 
@@ -209,6 +207,7 @@ The following attribute are exported:
 * `computed_size` - Size (in MB) of the image attached to the virtual machine. Not possible to change a cloned image size.
 * `computed_target` - Target name device on the virtual machine. Depends of the image `dev_prefix`.
 * `computed_driver` - OpenNebula image driver.
+* `computed_volatile_format` - Format of the Image: `raw` or `qcow2`.
 
 ## Instantiate from a template
 
@@ -240,4 +239,3 @@ Verify that Terraform does not perform any change:
 ```
 terraform plan
 ```
-


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

Proposal to fix volatile disk update test failure for OpenNebula 6.2.
This adds new attribute `computed_volatile_disk` with computed behavior only. The read operation for the `volatile_format` attribute is now conditional: the value is read only when set by the user to ensure that values match.

This replace #240 fix, which tried to apply a default value. The problem is: should we define a default value everytime, even when a non volatile disk is defined ?

### References

Close issue #239  

### New or Affected Resource(s)

- `opennebula_virtual_machine`

### Checklist

<!--- Please check you didn't forgot a step to help us merging this PR. --->

- [ ] I have created an issue and I have mentioned it in `References`
- [ ] My code follows the style guidelines of this project (use `go fmt`)
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the unit tests and they pass succesfuly
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation (if needed)
- [ ] I have updated the changelog file
