### PR TITLE
F-212: Enable VM resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ ENHANCEMENTS:
 * data/opennebula_virtual_network: make `name` optional and enable `tags` filtering
 * resources/opennebula_group: add `sunstone` and `tags` sections
 * resources/opennebula_virtual_network: compatibility added for network states
+* resources/opennebula_virtal_machine: enable VM vcpu, cpu and memory update
 
 FEATURES:
 

--- a/opennebula/resource_opennebula_virtual_machine_test.go
+++ b/opennebula/resource_opennebula_virtual_machine_test.go
@@ -486,6 +486,64 @@ func TestAccVirtualMachinePending(t *testing.T) {
 	})
 }
 
+func TestAccVirtualMachineResize(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVirtualMachineDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVirtualMachineTemplateConfigBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccSetDSdummy(),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "name", "test-virtual_machine"),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "memory", "128"),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "cpu", "0.1"),
+				),
+			},
+			{
+				Config: testAccVirtualMachineTemplateAddvCPU,
+				Check: resource.ComposeTestCheckFunc(
+					testAccSetDSdummy(),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "name", "test-virtual_machine"),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "vcpu", "1"),
+				),
+			},
+			{
+				Config: testAccVirtualMachineResizeCpu,
+				Check: resource.ComposeTestCheckFunc(
+					testAccSetDSdummy(),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "name", "test-virtual_machine"),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "cpu", "0.3"),
+				),
+			},
+			{
+				Config: testAccVirtualMachineResizevCpu,
+				Check: resource.ComposeTestCheckFunc(
+					testAccSetDSdummy(),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "name", "test-virtual_machine"),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "vcpu", "2"),
+				),
+			},
+			{
+				Config: testAccVirtualMachineResizeMemory,
+				Check: resource.ComposeTestCheckFunc(
+					testAccSetDSdummy(),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "name", "test-virtual_machine"),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "memory", "256"),
+				),
+			},
+			{
+				Config: testAccVirtualMachineResizePoweroffHard,
+				Check: resource.ComposeTestCheckFunc(
+					testAccSetDSdummy(),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "name", "test-virtual_machine"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccVirtualMachineTemplateNIC(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -1744,5 +1802,204 @@ resource "opennebula_virtual_machine" "test" {
 	}
 
 	timeout = 5
+}
+`
+
+var testAccVirtualMachineTemplateAddvCPU = `
+resource "opennebula_virtual_machine" "test" {
+  name        = "test-virtual_machine"
+  group       = "oneadmin"
+  permissions = "642"
+  memory = 128
+  cpu = 0.1
+  vcpu = 1
+  description = "VM created for provider acceptance tests"
+
+  context = {
+	TESTVAR = "TEST"
+	NETWORK  = "YES"
+	SET_HOSTNAME = "$NAME"
+  }
+
+  graphics {
+    type   = "VNC"
+    listen = "0.0.0.0"
+    keymap = "en-us"
+  }
+
+  disk {}
+
+  os {
+    arch = "x86_64"
+    boot = ""
+  }
+
+  tags = {
+    env = "prod"
+    customer = "test"
+  }
+
+  sched_requirements = "FREE_CPU > 50"
+
+  timeout = 5
+}
+`
+
+var testAccVirtualMachineResizeCpu = `
+resource "opennebula_virtual_machine" "test" {
+  name        = "test-virtual_machine"
+  group       = "oneadmin"
+  permissions = "642"
+  memory = 128
+  cpu = 0.3
+  description = "VM created for provider acceptance tests"
+
+  context = {
+	TESTVAR = "TEST"
+	NETWORK  = "YES"
+	SET_HOSTNAME = "$NAME"
+  }
+
+  graphics {
+    type   = "VNC"
+    listen = "0.0.0.0"
+    keymap = "en-us"
+  }
+
+  disk {}
+
+  os {
+    arch = "x86_64"
+    boot = ""
+  }
+
+  tags = {
+    env = "prod"
+    customer = "test"
+  }
+
+  sched_requirements = "FREE_CPU > 50"
+
+  timeout = 5
+}
+`
+
+var testAccVirtualMachineResizevCpu = `
+resource "opennebula_virtual_machine" "test" {
+  name        = "test-virtual_machine"
+  group       = "oneadmin"
+  permissions = "642"
+  memory = 128
+  cpu = 0.3
+  vcpu = 2
+  description = "VM created for provider acceptance tests"
+
+  context = {
+	TESTVAR = "TEST"
+	NETWORK  = "YES"
+	SET_HOSTNAME = "$NAME"
+  }
+
+  graphics {
+    type   = "VNC"
+    listen = "0.0.0.0"
+    keymap = "en-us"
+  }
+
+  disk {}
+
+  os {
+    arch = "x86_64"
+    boot = ""
+  }
+
+  tags = {
+    env = "prod"
+    customer = "test"
+  }
+
+  sched_requirements = "FREE_CPU > 50"
+
+  timeout = 5
+}
+`
+
+var testAccVirtualMachineResizeMemory = `
+resource "opennebula_virtual_machine" "test" {
+  name        = "test-virtual_machine"
+  group       = "oneadmin"
+  permissions = "642"
+  memory = 256
+  cpu = 0.3
+  vcpu  = 2
+  description = "VM created for provider acceptance tests"
+  context = {
+	TESTVAR = "TEST"
+	NETWORK  = "YES"
+	SET_HOSTNAME = "$NAME"
+  }
+
+  graphics {
+    type   = "VNC"
+    listen = "0.0.0.0"
+    keymap = "en-us"
+  }
+
+  disk {}
+
+  os {
+    arch = "x86_64"
+    boot = ""
+  }
+
+  tags = {
+    env = "prod"
+    customer = "test"
+  }
+
+  sched_requirements = "FREE_CPU > 50"
+
+  timeout = 5
+}
+`
+
+var testAccVirtualMachineResizePoweroffHard = `
+resource "opennebula_virtual_machine" "test" {
+  name        = "test-virtual_machine"
+  group       = "oneadmin"
+  permissions = "642"
+  memory = 256
+  cpu = 0.3
+  vcpu  = 2
+  hard_shutdown = true
+  description = "VM created for provider acceptance tests"
+
+  context = {
+	TESTVAR = "TEST"
+	NETWORK  = "YES"
+	SET_HOSTNAME = "$NAME"
+  }
+
+  graphics {
+    type   = "VNC"
+    listen = "0.0.0.0"
+    keymap = "en-us"
+  }
+
+  disk {}
+
+  os {
+    arch = "x86_64"
+    boot = ""
+  }
+
+  tags = {
+    env = "prod"
+    customer = "test"
+  }
+
+  sched_requirements = "FREE_CPU > 50"
+
+  timeout = 5
 }
 `

--- a/opennebula/shared_schemas.go
+++ b/opennebula/shared_schemas.go
@@ -61,6 +61,12 @@ func commonVMSchemas() map[string]*schema.Schema {
 			},
 			"template_disk": templateDiskVMSchema(),
 			"disk":          diskVMSchema(),
+			"hard_shutdown": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Immediately poweroff/terminate/reboot/undeploy the VM. (default: false)",
+			},
 		},
 	)
 }

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -100,6 +100,7 @@ The following arguments are supported:
 * `timeout` - (Optional) Timeout (in Minutes) for VM availability. Defaults to 3 minutes.
 * `lock` - (Optional) Lock the VM with a specific lock level. Supported values: `USE`, `MANAGE`, `ADMIN`, `ALL` or `UNLOCK`.
 * `on_disk_change` - (Optional) Select the behavior for changing disk images. Supported values: `RECREATE` or `SWAP` (default). `RECREATE` forces recreation of the vm and `SWAP` adopts the standard behavior of hot-swapping the disks. NOTE: This property does not affect the behavior of adding new disks.
+* `hard_shutdown` - (Optional) If the VM doesn't have ACPI support, it immediately poweroff/terminate/reboot/undeploy the VM. Defaults to false.
 
 ### Graphics parameters
 


### PR DESCRIPTION
This is a PR that apply some small changes to #211 authored by @Cookiiiies

The option `poweroff_hard_on_resize` has been renamed, to be able to use for all VM actions (not only on resize). 
By the way, this option has been used for the terminate action used to delete the VM.

This change a bit the behavior of the provider: by default the hard behavior was in use in the provider to delete a VM. Now, by default, it's now turned off, it's a bit less violent and slower but I don't think it's a problem.
To keep the same behavior than before set the `hard_shutdown` option to `true`

Close #212

Should be merged at the same time than #236