### PR TITLE
B-284: fix template datasource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ BUG FIXES:
 
 * provider: Fix incorrect conversions between integer types (#278)
 * provider: Fail on bad credentials (#288)
+* data/opennebula_template: Fix error when `cpu`, `vcpu` or `memory` undefined (#284)
 
 ## 0.5.0 (June 7th, 2022)
 

--- a/opennebula/data_opennebula_cluster.go
+++ b/opennebula/data_opennebula_cluster.go
@@ -56,9 +56,9 @@ func clusterFilter(d *schema.ResourceData, meta interface{}) (*clusterSc.Cluster
 
 	// check filtering results
 	if len(match) == 0 {
-		return nil, fmt.Errorf("no cluster match the tags")
+		return nil, fmt.Errorf("no cluster match the constraints")
 	} else if len(match) > 1 {
-		return nil, fmt.Errorf("several clusters match the tags")
+		return nil, fmt.Errorf("several clusters match the constraints")
 	}
 
 	return match[0], nil

--- a/opennebula/data_opennebula_group.go
+++ b/opennebula/data_opennebula_group.go
@@ -70,9 +70,9 @@ func groupFilter(d *schema.ResourceData, meta interface{}) (*groupSc.GroupShort,
 
 	// check filtering results
 	if len(match) == 0 {
-		return nil, fmt.Errorf("no group match the tags")
+		return nil, fmt.Errorf("no group match the constraints")
 	} else if len(match) > 1 {
-		return nil, fmt.Errorf("several groups match the tags")
+		return nil, fmt.Errorf("several groups match the constraints")
 	}
 
 	return match[0], nil

--- a/opennebula/data_opennebula_image.go
+++ b/opennebula/data_opennebula_image.go
@@ -56,9 +56,9 @@ func imageFilter(d *schema.ResourceData, meta interface{}) (*imageSc.Image, erro
 
 	// check filtering results
 	if len(match) == 0 {
-		return nil, fmt.Errorf("no image match the tags")
+		return nil, fmt.Errorf("no image match the constraints")
 	} else if len(match) > 1 {
-		return nil, fmt.Errorf("several images match the tags")
+		return nil, fmt.Errorf("several images match the constraints")
 	}
 
 	return match[0], nil

--- a/opennebula/data_opennebula_security_group.go
+++ b/opennebula/data_opennebula_security_group.go
@@ -56,9 +56,9 @@ func securityGroupFilter(d *schema.ResourceData, meta interface{}) (*secgroup.Se
 
 	// check filtering results
 	if len(match) == 0 {
-		return nil, fmt.Errorf("no security group match the tags")
+		return nil, fmt.Errorf("no security group match the constraints")
 	} else if len(match) > 1 {
-		return nil, fmt.Errorf("several security group match the tags")
+		return nil, fmt.Errorf("several security group match the constraints")
 	}
 
 	return match[0], nil

--- a/opennebula/data_opennebula_template_vm_group.go
+++ b/opennebula/data_opennebula_template_vm_group.go
@@ -56,9 +56,9 @@ func vmGroupFilter(d *schema.ResourceData, meta interface{}) (*vmGroupSc.VMGroup
 
 	// check filtering results
 	if len(match) == 0 {
-		return nil, fmt.Errorf("no vm group match the tags")
+		return nil, fmt.Errorf("no vm group match the constraints")
 	} else if len(match) > 1 {
-		return nil, fmt.Errorf("several vm group match the tags")
+		return nil, fmt.Errorf("several vm group match the constraints")
 	}
 
 	return match[0], nil

--- a/opennebula/data_opennebula_user.go
+++ b/opennebula/data_opennebula_user.go
@@ -115,9 +115,9 @@ userLoop:
 
 	// check filtering results
 	if len(match) == 0 {
-		return nil, fmt.Errorf("no user match the tags")
+		return nil, fmt.Errorf("no user match the constraints")
 	} else if len(match) > 1 {
-		return nil, fmt.Errorf("several users match the tags")
+		return nil, fmt.Errorf("several users match the constraints")
 	}
 
 	return match[0], nil

--- a/opennebula/data_opennebula_virtual_data_center.go
+++ b/opennebula/data_opennebula_virtual_data_center.go
@@ -56,9 +56,9 @@ func vdcFilter(d *schema.ResourceData, meta interface{}) (*vdcSc.VDC, error) {
 
 	// check filtering results
 	if len(match) == 0 {
-		return nil, fmt.Errorf("no virtual data center match the tags")
+		return nil, fmt.Errorf("no virtual data center match the constraints")
 	} else if len(match) > 1 {
-		return nil, fmt.Errorf("several virtual data centers match the tags")
+		return nil, fmt.Errorf("several virtual data centers match the constraints")
 	}
 
 	return match[0], nil

--- a/opennebula/data_opennebula_virtual_network.go
+++ b/opennebula/data_opennebula_virtual_network.go
@@ -68,9 +68,9 @@ func vnetFilter(d *schema.ResourceData, meta interface{}) (*vnetSc.VirtualNetwor
 
 	// check filtering results
 	if len(match) == 0 {
-		return nil, fmt.Errorf("no virtual network match the tags")
+		return nil, fmt.Errorf("no virtual network match the constraints")
 	} else if len(match) > 1 {
-		return nil, fmt.Errorf("several virtual networks match the tags")
+		return nil, fmt.Errorf("several virtual networks match the constraints")
 	}
 
 	return match[0], nil


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

The problem was introduced by PR #229 (issue #226), in which I reworked all datasources.
This is probably due a template that doesn't define some fields among `cpu`, `vcpu`, `memory`: the code supposed that they have to be defined.
By the way, I found the error messages confusing: `tags` is the name of an other field, which is not at the origin of the error I'm fixing here.

### References

Close #284
Fix #226
Fix #287

### New or Affected Resource(s)

<!--- Please list the new or affected resources and data sources. --->

- opennebula_template

### Checklist

<!--- Please check you didn't forgot a step to help us merging this PR. --->

- [ ] I have created an issue and I have mentioned it in `References`
- [ ] My code follows the style guidelines of this project (use `go fmt`)
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the unit tests and they pass succesfuly
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation (if needed)
- [ ] I have updated the changelog file
