### PR TITLE
B #278: fix integer conversions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.5.1 (Unreleased)
+
+BUG FIXES:
+
+* provider: Fix incorrect conversions between integer types (#278)
+
 ## 0.5.0 (June 7th, 2022)
 
 NOTES:

--- a/opennebula/resource_opennebula_acl_test.go
+++ b/opennebula/resource_opennebula_acl_test.go
@@ -62,7 +62,7 @@ func testAccCheckACLDestroy(s *terraform.State) error {
 	}
 
 	for _, rs := range s.RootModule().Resources {
-		id, _ := strconv.ParseUint(rs.Primary.ID, 10, 64)
+		id, _ := strconv.ParseUint(rs.Primary.ID, 10, 0)
 		for _, acl := range acls.ACLs {
 			if int(id) == acl.ID {
 				return fmt.Errorf("Expected group %s to have been destroyed", rs.Primary.ID)

--- a/opennebula/resource_opennebula_group.go
+++ b/opennebula/resource_opennebula_group.go
@@ -110,7 +110,7 @@ func getGroupController(d *schema.ResourceData, meta interface{}) (*goca.GroupCo
 
 	// Try to find the Group by ID, if specified
 	if d.Id() != "" {
-		gid, err := strconv.ParseUint(d.Id(), 10, 64)
+		gid, err := strconv.ParseUint(d.Id(), 10, 0)
 		if err != nil {
 			return nil, err
 		}

--- a/opennebula/resource_opennebula_group_admins.go
+++ b/opennebula/resource_opennebula_group_admins.go
@@ -61,7 +61,7 @@ func resourceOpennebulaGroupAdminsRead(d *schema.ResourceData, meta interface{})
 	config := meta.(*Configuration)
 	controller := config.Controller
 
-	groupID, err := strconv.ParseInt(d.Id(), 10, 64)
+	groupID, err := strconv.ParseInt(d.Id(), 10, 0)
 	if err != nil {
 		return err
 	}
@@ -84,7 +84,7 @@ func resourceOpennebulaGroupAdminsUpdate(d *schema.ResourceData, meta interface{
 	config := meta.(*Configuration)
 	controller := config.Controller
 
-	groupID, err := strconv.ParseInt(d.Id(), 10, 64)
+	groupID, err := strconv.ParseInt(d.Id(), 10, 0)
 	if err != nil {
 		return err
 	}
@@ -122,7 +122,7 @@ func resourceOpennebulaGroupAdminsDelete(d *schema.ResourceData, meta interface{
 	config := meta.(*Configuration)
 	controller := config.Controller
 
-	groupID, err := strconv.ParseInt(d.Id(), 10, 64)
+	groupID, err := strconv.ParseInt(d.Id(), 10, 0)
 	if err != nil {
 		return err
 	}

--- a/opennebula/resource_opennebula_group_test.go
+++ b/opennebula/resource_opennebula_group_test.go
@@ -117,7 +117,7 @@ func testAccCheckGroupDestroy(s *terraform.State) error {
 	controller := config.Controller
 
 	for _, rs := range s.RootModule().Resources {
-		groupID, _ := strconv.ParseUint(rs.Primary.ID, 10, 64)
+		groupID, _ := strconv.ParseUint(rs.Primary.ID, 10, 0)
 		gc := controller.Group(int(groupID))
 		// Get Group Info
 		// TODO: fix it after 5.10 release

--- a/opennebula/resource_opennebula_image.go
+++ b/opennebula/resource_opennebula_image.go
@@ -193,7 +193,7 @@ func getImageController(d *schema.ResourceData, meta interface{}, args ...int) (
 
 	// Try to find the Image by ID, if specified
 	if d.Id() != "" {
-		gid, err := strconv.ParseUint(d.Id(), 10, 64)
+		gid, err := strconv.ParseUint(d.Id(), 10, 0)
 		if err != nil {
 			return nil, err
 		}

--- a/opennebula/resource_opennebula_image_test.go
+++ b/opennebula/resource_opennebula_image_test.go
@@ -114,7 +114,7 @@ func testAccCheckImageDestroy(s *terraform.State) error {
 	controller := config.Controller
 
 	for _, rs := range s.RootModule().Resources {
-		imageID, _ := strconv.ParseUint(rs.Primary.ID, 10, 64)
+		imageID, _ := strconv.ParseUint(rs.Primary.ID, 10, 0)
 		ic := controller.Image(int(imageID))
 		// Get Image Info
 		// TODO: fix it after 5.10 release
@@ -134,7 +134,7 @@ func testAccCheckImagePermissions(expected *shared.Permissions, resourcename str
 		controller := config.Controller
 
 		for _, rs := range s.RootModule().Resources {
-			imageID, _ := strconv.ParseUint(rs.Primary.ID, 10, 64)
+			imageID, _ := strconv.ParseUint(rs.Primary.ID, 10, 0)
 			ic := controller.Image(int(imageID))
 			// Get image Info
 			// TODO: fix it after 5.10 release

--- a/opennebula/resource_opennebula_security_group.go
+++ b/opennebula/resource_opennebula_security_group.go
@@ -176,7 +176,7 @@ func getSecurityGroupController(d *schema.ResourceData, meta interface{}, args .
 
 	// Try to find the Security Group by ID, if specified
 	if d.Id() != "" {
-		gid, err := strconv.ParseUint(d.Id(), 10, 64)
+		gid, err := strconv.ParseUint(d.Id(), 10, 0)
 		if err != nil {
 			return nil, err
 		}

--- a/opennebula/resource_opennebula_security_group_test.go
+++ b/opennebula/resource_opennebula_security_group_test.go
@@ -61,7 +61,7 @@ func testAccCheckSecurityGroupDestroy(s *terraform.State) error {
 	controller := config.Controller
 
 	for _, rs := range s.RootModule().Resources {
-		sgID, _ := strconv.ParseUint(rs.Primary.ID, 10, 64)
+		sgID, _ := strconv.ParseUint(rs.Primary.ID, 10, 0)
 		sgc := controller.SecurityGroup(int(sgID))
 		// Get Security Group Info
 		// TODO: fix it after 5.10 release
@@ -81,7 +81,7 @@ func testAccSecurityGroupRule(ruleidx int, key, value string) resource.TestCheck
 		controller := config.Controller
 
 		for _, rs := range s.RootModule().Resources {
-			sgID, _ := strconv.ParseUint(rs.Primary.ID, 10, 64)
+			sgID, _ := strconv.ParseUint(rs.Primary.ID, 10, 0)
 			sgc := controller.SecurityGroup(int(sgID))
 			// Get Security Group Info
 			// TODO: fix it after 5.10 release

--- a/opennebula/resource_opennebula_service.go
+++ b/opennebula/resource_opennebula_service.go
@@ -405,7 +405,7 @@ func getServiceController(d *schema.ResourceData, meta interface{}) (*goca.Servi
 	var sc *goca.ServiceController
 
 	if d.Id() != "" {
-		id, err := strconv.ParseUint(d.Id(), 10, 64)
+		id, err := strconv.ParseUint(d.Id(), 10, 0)
 		if err != nil {
 			return nil, err
 		}

--- a/opennebula/resource_opennebula_service_template.go
+++ b/opennebula/resource_opennebula_service_template.go
@@ -325,7 +325,7 @@ func getServiceTemplateController(d *schema.ResourceData, meta interface{}) (*go
 	var stc *goca.STemplateController
 
 	if d.Id() != "" {
-		id, err := strconv.ParseUint(d.Id(), 10, 64)
+		id, err := strconv.ParseUint(d.Id(), 10, 0)
 		if err != nil {
 			return nil, err
 		}

--- a/opennebula/resource_opennebula_service_template_test.go
+++ b/opennebula/resource_opennebula_service_template_test.go
@@ -69,7 +69,7 @@ func testAccCheckServiceTemplateDestroy(s *terraform.State) error {
 		if rs.Type != "opennebula_service_template" {
 			continue
 		}
-		stID, _ := strconv.ParseUint(rs.Primary.ID, 10, 64)
+		stID, _ := strconv.ParseUint(rs.Primary.ID, 10, 0)
 		stc := controller.STemplate(int(stID))
 		// Get Service Info
 		stemplate, _ := stc.Info()
@@ -87,7 +87,7 @@ func testAccCheckServiceTemplatePermissions(expected *shared.Permissions) resour
 		controller := config.Controller
 
 		for _, rs := range s.RootModule().Resources {
-			stID, _ := strconv.ParseUint(rs.Primary.ID, 10, 64)
+			stID, _ := strconv.ParseUint(rs.Primary.ID, 10, 0)
 			stc := controller.STemplate(int(stID))
 			// Get Service
 			stemplate, _ := stc.Info()

--- a/opennebula/resource_opennebula_service_test.go
+++ b/opennebula/resource_opennebula_service_test.go
@@ -72,7 +72,7 @@ func testAccCheckServiceDestroy(s *terraform.State) error {
 		if rs.Type != "opennebula_service" {
 			continue
 		}
-		svID, _ := strconv.ParseUint(rs.Primary.ID, 10, 64)
+		svID, _ := strconv.ParseUint(rs.Primary.ID, 10, 0)
 		sc := controller.Service(int(svID))
 		// Get Service Info
 		service, _ := sc.Info()
@@ -93,7 +93,7 @@ func testAccCheckServicePermissions(expected *shared.Permissions) resource.TestC
 		controller := config.Controller
 
 		for _, rs := range s.RootModule().Resources {
-			serviceID, _ := strconv.ParseUint(rs.Primary.ID, 10, 64)
+			serviceID, _ := strconv.ParseUint(rs.Primary.ID, 10, 0)
 			sc := controller.Service(int(serviceID))
 			// Get Service
 			service, _ := sc.Info()

--- a/opennebula/resource_opennebula_template.go
+++ b/opennebula/resource_opennebula_template.go
@@ -201,7 +201,7 @@ func getTemplateController(d *schema.ResourceData, meta interface{}, args ...int
 
 	// Try to find the template by ID, if specified
 	if d.Id() != "" {
-		gid, err := strconv.ParseUint(d.Id(), 10, 64)
+		gid, err := strconv.ParseUint(d.Id(), 10, 0)
 		if err != nil {
 			return nil, err
 		}

--- a/opennebula/resource_opennebula_template_test.go
+++ b/opennebula/resource_opennebula_template_test.go
@@ -167,7 +167,7 @@ func testAccCheckTemplatePermissions(expected *shared.Permissions) resource.Test
 			if rs.Type != "opennebula_template" {
 				continue
 			}
-			tID, _ := strconv.ParseUint(rs.Primary.ID, 10, 64)
+			tID, _ := strconv.ParseUint(rs.Primary.ID, 10, 0)
 			tc := controller.Template(int(tID))
 			// TODO: fix it after 5.10 release availability
 			// Force the "extended" bool to false to keep ONE 5.8 behavior
@@ -199,7 +199,7 @@ func testAccCheckTemplateDestroy(s *terraform.State) error {
 		if rs.Type != "opennebula_template" {
 			continue
 		}
-		templateID, _ := strconv.ParseUint(rs.Primary.ID, 10, 64)
+		templateID, _ := strconv.ParseUint(rs.Primary.ID, 10, 0)
 		tc := controller.Template(int(templateID))
 		// Get Template Info
 		template, _ := tc.Info(false, false)

--- a/opennebula/resource_opennebula_template_vm_group.go
+++ b/opennebula/resource_opennebula_template_vm_group.go
@@ -144,7 +144,7 @@ func getVMGroupController(d *schema.ResourceData, meta interface{}, args ...int)
 
 	// Try to find the vm group by ID, if specified
 	if d.Id() != "" {
-		gid, err := strconv.ParseUint(d.Id(), 10, 64)
+		gid, err := strconv.ParseUint(d.Id(), 10, 0)
 		if err != nil {
 			return nil, err
 		}
@@ -300,14 +300,14 @@ func flattenVMGroupRoles(d *schema.ResourceData, vmgRoles []vmgroup.Role) error 
 		if vmgr.HostAffined != "" {
 			hostAffString := strings.Split(vmgr.HostAffined, ",")
 			for _, h := range hostAffString {
-				hostAffInt, _ := strconv.ParseInt(h, 10, 32)
+				hostAffInt, _ := strconv.ParseInt(h, 10, 0)
 				hAff = append(hAff, int(hostAffInt))
 			}
 		}
 		if vmgr.HostAntiAffined != "" {
 			hostAntiAffString := strings.Split(vmgr.HostAntiAffined, ",")
 			for _, h := range hostAntiAffString {
-				hostAntiAffInt, _ := strconv.ParseInt(h, 10, 32)
+				hostAntiAffInt, _ := strconv.ParseInt(h, 10, 0)
 				hAntiAff = append(hAff, int(hostAntiAffInt))
 			}
 		}

--- a/opennebula/resource_opennebula_template_vm_group_test.go
+++ b/opennebula/resource_opennebula_template_vm_group_test.go
@@ -71,7 +71,7 @@ func testAccCheckVMGroupDestroy(s *terraform.State) error {
 		if rs.Type != "opennebula_virtual_machine_group" {
 			continue
 		}
-		vmgID, _ := strconv.ParseUint(rs.Primary.ID, 10, 64)
+		vmgID, _ := strconv.ParseUint(rs.Primary.ID, 10, 0)
 		vmgc := controller.VMGroup(int(vmgID))
 		// Get Virtual Machine Group Info
 		vmg, _ := vmgc.Info(false)
@@ -92,7 +92,7 @@ func testAccCheckVMGroupPermissions(expected *shared.Permissions) resource.TestC
 			if rs.Type != "opennebula_virtual_machine_group" {
 				continue
 			}
-			vmgID, _ := strconv.ParseUint(rs.Primary.ID, 10, 64)
+			vmgID, _ := strconv.ParseUint(rs.Primary.ID, 10, 0)
 			vmgc := controller.VMGroup(int(vmgID))
 			// Get Virtual Machine Group Info
 			vmg, _ := vmgc.Info(false)

--- a/opennebula/resource_opennebula_user.go
+++ b/opennebula/resource_opennebula_user.go
@@ -80,7 +80,7 @@ func getUserController(d *schema.ResourceData, meta interface{}) (*goca.UserCont
 
 	// Try to find the User by ID, if specified
 	if d.Id() != "" {
-		uid, err := strconv.ParseUint(d.Id(), 10, 64)
+		uid, err := strconv.ParseUint(d.Id(), 10, 0)
 		if err != nil {
 			return nil, err
 		}

--- a/opennebula/resource_opennebula_user_test.go
+++ b/opennebula/resource_opennebula_user_test.go
@@ -68,7 +68,7 @@ func testAccCheckUserDestroy(s *terraform.State) error {
 	controller := config.Controller
 
 	for _, rs := range s.RootModule().Resources {
-		userID, _ := strconv.ParseUint(rs.Primary.ID, 10, 64)
+		userID, _ := strconv.ParseUint(rs.Primary.ID, 10, 0)
 		uc := controller.User(int(userID))
 		// Get User Info
 		// TODO: fix it after 5.10 release

--- a/opennebula/resource_opennebula_virtual_data_center.go
+++ b/opennebula/resource_opennebula_virtual_data_center.go
@@ -106,7 +106,7 @@ func getVDCController(d *schema.ResourceData, meta interface{}) (*goca.VDCContro
 
 	// Try to find the VDC by ID, if specified
 	if d.Id() != "" {
-		vdcid, err := strconv.ParseUint(d.Id(), 10, 64)
+		vdcid, err := strconv.ParseUint(d.Id(), 10, 0)
 		if err != nil {
 			return nil, err
 		}

--- a/opennebula/resource_opennebula_virtual_data_center_test.go
+++ b/opennebula/resource_opennebula_virtual_data_center_test.go
@@ -60,7 +60,7 @@ func testAccCheckVirtualDataCenterDestroy(s *terraform.State) error {
 		if rs.Type != "opennebula_virtual_data_center" {
 			continue
 		}
-		vdcID, _ := strconv.ParseUint(rs.Primary.ID, 10, 64)
+		vdcID, _ := strconv.ParseUint(rs.Primary.ID, 10, 0)
 		vdcc := controller.VDC(int(vdcID))
 		// Get Virtual Data Center Info
 		vdc, _ := vdcc.Info(false)
@@ -81,7 +81,7 @@ func testAccCheckVirtualDataCenterGroups(slice []int) resource.TestCheckFunc {
 			if rs.Type != "opennebula_virtual_data_center" {
 				continue
 			}
-			vdcID, _ := strconv.ParseUint(rs.Primary.ID, 10, 64)
+			vdcID, _ := strconv.ParseUint(rs.Primary.ID, 10, 0)
 			vdcc := controller.VDC(int(vdcID))
 			// Get Virtual Data Center Info
 			vdc, _ := vdcc.Info(false)
@@ -105,7 +105,7 @@ func testAccCheckVirtualDataCenterZones(zoneidx int, expected map[string]interfa
 			if rs.Type != "opennebula_virtual_data_center" {
 				continue
 			}
-			vdcID, _ := strconv.ParseUint(rs.Primary.ID, 10, 64)
+			vdcID, _ := strconv.ParseUint(rs.Primary.ID, 10, 0)
 			vdcc := controller.VDC(int(vdcID))
 			// Get Virtual Data Center Info
 			vdc, _ := vdcc.Info(false)

--- a/opennebula/resource_opennebula_virtual_machine.go
+++ b/opennebula/resource_opennebula_virtual_machine.go
@@ -210,7 +210,7 @@ func getVirtualMachineController(d *schema.ResourceData, meta interface{}, args 
 
 		// Try to find the VM by ID, if specified
 
-		id, err := strconv.ParseUint(d.Id(), 10, 64)
+		id, err := strconv.ParseUint(d.Id(), 10, 0)
 		if err != nil {
 			return nil, err
 		}

--- a/opennebula/resource_opennebula_virtual_machine_test.go
+++ b/opennebula/resource_opennebula_virtual_machine_test.go
@@ -604,7 +604,7 @@ func testAccCheckVirtualMachineDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "opennebula_image":
-			imgID, _ := strconv.ParseUint(rs.Primary.ID, 10, 64)
+			imgID, _ := strconv.ParseUint(rs.Primary.ID, 10, 0)
 			imgc := controller.Image(int(imgID))
 			// Get Virtual Machine Info
 			img, _ := imgc.Info(false)
@@ -616,7 +616,7 @@ func testAccCheckVirtualMachineDestroy(s *terraform.State) error {
 			}
 
 		case "opennebula_virtual_machine":
-			vmID, _ := strconv.ParseUint(rs.Primary.ID, 10, 64)
+			vmID, _ := strconv.ParseUint(rs.Primary.ID, 10, 0)
 			vmc := controller.VM(int(vmID))
 			// Get Virtual Machine Info
 			vm, _ := vmc.Info(false)
@@ -659,7 +659,7 @@ func testAccCheckVirtualMachinePermissions(expected *shared.Permissions) resourc
 			switch rs.Type {
 			case "opennebula_virtual_machine":
 
-				vmID, _ := strconv.ParseUint(rs.Primary.ID, 10, 64)
+				vmID, _ := strconv.ParseUint(rs.Primary.ID, 10, 0)
 				vmc := controller.VM(int(vmID))
 				// Get Virtual Machine Info
 				vm, err := vmc.Info(false)

--- a/opennebula/resource_opennebula_virtual_network.go
+++ b/opennebula/resource_opennebula_virtual_network.go
@@ -336,7 +336,7 @@ func getVirtualNetworkController(d *schema.ResourceData, meta interface{}, args 
 
 	// Try to find the VNet by ID, if specified
 	if d.Id() != "" {
-		id, err := strconv.ParseUint(d.Id(), 10, 64)
+		id, err := strconv.ParseUint(d.Id(), 10, 0)
 		if err != nil {
 			return nil, err
 		}
@@ -889,7 +889,7 @@ func flattenVnetTemplate(d *schema.ResourceData, vnTpl *vn.Template) error {
 		case "MTU":
 			mtustr, _ := vnTpl.Get("MTU")
 			if mtustr != "" {
-				mtu, err := strconv.ParseInt(mtustr, 10, 64)
+				mtu, err := strconv.ParseInt(mtustr, 10, 0)
 				if err != nil {
 					return err
 				}

--- a/opennebula/resource_opennebula_virtual_network_test.go
+++ b/opennebula/resource_opennebula_virtual_network_test.go
@@ -154,7 +154,7 @@ func testAccCheckVirtualNetworkDestroy(s *terraform.State) error {
 	controller := config.Controller
 
 	for _, rs := range s.RootModule().Resources {
-		vnID, _ := strconv.ParseUint(rs.Primary.ID, 10, 64)
+		vnID, _ := strconv.ParseUint(rs.Primary.ID, 10, 0)
 		vnc := controller.VirtualNetwork(int(vnID))
 
 		// Wait for Virtual Network deleted
@@ -188,7 +188,7 @@ func testAccCheckVirtualNetworkPermissions(expected *shared.Permissions) resourc
 		controller := config.Controller
 
 		for _, rs := range s.RootModule().Resources {
-			vnID, _ := strconv.ParseUint(rs.Primary.ID, 10, 64)
+			vnID, _ := strconv.ParseUint(rs.Primary.ID, 10, 0)
 			vnc := controller.VirtualNetwork(int(vnID))
 			// Get Virtual Network Info
 			// TODO: fix it after 5.10 release
@@ -218,7 +218,7 @@ func testAccVirtualNetworkSG(slice []int) resource.TestCheckFunc {
 		controller := config.Controller
 
 		for _, rs := range s.RootModule().Resources {
-			vnID, _ := strconv.ParseUint(rs.Primary.ID, 10, 64)
+			vnID, _ := strconv.ParseUint(rs.Primary.ID, 10, 0)
 			vnc := controller.VirtualNetwork(int(vnID))
 			// Get Virtual Network Info
 			// TODO: fix it after 5.10 release

--- a/opennebula/resource_opennebula_virtual_router.go
+++ b/opennebula/resource_opennebula_virtual_router.go
@@ -114,7 +114,7 @@ func getVirtualRouterController(d *schema.ResourceData, meta interface{}, args .
 
 	// Try to find the virtual router by ID, if specified
 	if d.Id() != "" {
-		gid, err := strconv.ParseUint(d.Id(), 10, 64)
+		gid, err := strconv.ParseUint(d.Id(), 10, 0)
 		if err != nil {
 			return nil, err
 		}

--- a/opennebula/resource_opennebula_virtual_router_test.go
+++ b/opennebula/resource_opennebula_virtual_router_test.go
@@ -143,14 +143,14 @@ func testAccCheckVirtualRouterDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "opennebula_virtual_router":
-			vrID, _ := strconv.ParseUint(rs.Primary.ID, 10, 64)
+			vrID, _ := strconv.ParseUint(rs.Primary.ID, 10, 0)
 			vrc := controller.VirtualRouter(int(vrID))
 			vr, _ := vrc.Info(false)
 			if vr != nil {
 				return fmt.Errorf("Expected virtual router %s to have been destroyed", rs.Primary.ID)
 			}
 		case "opennebula_virtual_network":
-			vnID, _ := strconv.ParseUint(rs.Primary.ID, 10, 64)
+			vnID, _ := strconv.ParseUint(rs.Primary.ID, 10, 0)
 			vnc := controller.Template(int(vnID))
 			// Get Virtual Machine Info
 			vn, _ := vnc.Info(false, false)
@@ -158,7 +158,7 @@ func testAccCheckVirtualRouterDestroy(s *terraform.State) error {
 				return fmt.Errorf("Expected virtual network %s to have been destroyed", rs.Primary.ID)
 			}
 		case "opennebula_virtual_router_instance":
-			vmID, _ := strconv.ParseUint(rs.Primary.ID, 10, 64)
+			vmID, _ := strconv.ParseUint(rs.Primary.ID, 10, 0)
 			vmc := controller.VM(int(vmID))
 			// Get Virtual Machine Info
 			vm, _ := vmc.Info(false)
@@ -169,7 +169,7 @@ func testAccCheckVirtualRouterDestroy(s *terraform.State) error {
 				}
 			}
 		case "opennebula_virtual_router_instance_template":
-			tplID, _ := strconv.ParseUint(rs.Primary.ID, 10, 64)
+			tplID, _ := strconv.ParseUint(rs.Primary.ID, 10, 0)
 			tc := controller.Template(int(tplID))
 			// Get Virtual Machine Info
 			tpl, _ := tc.Info(false, false)
@@ -192,7 +192,7 @@ func testAccCheckVirtualRouterPermissions(expected *shared.Permissions, resource
 			switch rs.Type {
 			case "opennebula_virtual_router":
 
-				vrID, _ := strconv.ParseUint(rs.Primary.ID, 10, 64)
+				vrID, _ := strconv.ParseUint(rs.Primary.ID, 10, 0)
 				vrc := controller.VirtualRouter(int(vrID))
 				// Get virtual router Info
 				vrInfos, _ := vrc.Info(false)


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

All the errors mentioned in #278 are about type casting from int64 to int without check.

Here I'm fixing them in replacing a parameter of the strconv.Parse(Int/Uint) methods:

My understanding of the int type behavior:
```The int, uint, and uintptr types are usually 32 bits wide on 32-bit systems and 64 bits wide on 64-bit systems.```

And from the [ParseInt documentation](https://pkg.go.dev/strconv#ParseInt):
```
The bitSize argument specifies the integer type that the result must fit into. Bit sizes 0, 8, 16, 32, and 64 correspond to int, int8, int16, int32, and int64. If bitSize is below 0 or above 64, an error is returned.
```

With the 0 bit size, I expect the ParseInt method to fails if it tries to parse a 64 bits integer on a 32 bit system (i.e. int stored on 32 bits) on the system the provider is running (However I'll need to read the ParseInt source code to be sure).

### References

Close #278 

### New or Affected Resource(s)

<!--- Please list the new or affected resources and data sources. --->

- opennebula_group
- opennebula_group_admins
- opennebula_image
- opennebula_security_group
- opennebula_service
- opennebula_service_template
- opennebula_template
- opennebula_template_vm_group
- opennebula_user
- opennebula_virtual_data_center
- opennebula_virtual_machine
- opennebula_virtual_network
- opennebula_virtual_router

### Checklist

<!--- Please check you didn't forgot a step to help us merging this PR. --->

- [x] I have created an issue and I have mentioned it in `References`
- [x] My code follows the style guidelines of this project (use `go fmt`)
- [x] My changes generate no new warnings or errors
- [x] I have updated the unit tests and they pass succesfuly
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation (if needed)
- [x] I have updated the changelog file
