### PR TITLE
B-132: wait vm state

### DIFF
--- a/opennebula/helpers_vm.go
+++ b/opennebula/helpers_vm.go
@@ -48,11 +48,17 @@ func vmDiskAttach(ctx context.Context, vmc *goca.VMController, timeout time.Dura
 
 	}
 
-	// wait before checking disk
-	_, err = waitForVMState(ctx, vmc, timeout, vmDiskUpdateReadyStates...)
+	// wait before checking disk list
+	// final states ar added to transient one in case of slow cloud
+	transient := vmDiskTransientStates
+	transient.Append(vmDiskUpdateReadyStates)
+	finalStrs := vmDiskUpdateReadyStates.ToStrings()
+	stateConf := NewVMUpdateStateConf(timeout, transient.ToStrings(), finalStrs)
+
+	_, err = waitForVMStates(ctx, vmc, stateConf)
 	if err != nil {
 		return -1, fmt.Errorf(
-			"waiting for virtual machine (ID:%d) to be in state %s: %s", vmc.ID, strings.Join(vmDiskUpdateReadyStates, " "), err)
+			"waiting for virtual machine (ID:%d) to be in state %s: %s", vmc.ID, strings.Join(finalStrs, " "), err)
 	}
 
 	// compare disk list to check that a new disk is attached
@@ -122,11 +128,17 @@ func vmDiskDetach(ctx context.Context, vmc *goca.VMController, timeout time.Dura
 		return fmt.Errorf("can't detach disk %d: %s\n", diskID, err)
 	}
 
-	// wait before checking disk
-	_, err = waitForVMState(ctx, vmc, timeout, vmDiskUpdateReadyStates...)
+	// wait before checking disk list
+	// final states ar added to transient one in case of slow cloud
+	transient := vmDiskTransientStates.
+		Append(vmDiskUpdateReadyStates)
+	finalStrs := vmDiskUpdateReadyStates.ToStrings()
+	stateConf := NewVMUpdateStateConf(timeout, transient.ToStrings(), finalStrs)
+
+	_, err = waitForVMStates(ctx, vmc, stateConf)
 	if err != nil {
 		return fmt.Errorf(
-			"waiting for virtual machine (ID:%d) to be in state %s: %s", vmc.ID, strings.Join(vmDiskUpdateReadyStates, " "), err)
+			"waiting for virtual machine (ID:%d) to be in state %s: %s", vmc.ID, strings.Join(finalStrs, " "), err)
 	}
 
 	// Check that disk is detached
@@ -168,11 +180,17 @@ func vmDiskResize(ctx context.Context, vmc *goca.VMController, timeout time.Dura
 		return fmt.Errorf("can't resize image with Disk ID:%d: %s\n", diskID, err)
 	}
 
-	// wait before checking disk
-	_, err = waitForVMState(ctx, vmc, timeout, vmDiskResizeReadyStates...)
+	// wait before checking disk list
+	// final states ar added to transient one in case of slow cloud
+	transient := vmDiskTransientStates
+	transient.Append(vmDiskResizeReadyStates)
+	finalStrs := vmDiskResizeReadyStates.ToStrings()
+	stateConf := NewVMUpdateStateConf(timeout, transient.ToStrings(), finalStrs)
+
+	_, err = waitForVMStates(ctx, vmc, stateConf)
 	if err != nil {
 		return fmt.Errorf(
-			"waiting for virtual machine (ID:%d) to be in state %s: %s", vmc.ID, strings.Join(vmDiskUpdateReadyStates, " "), err)
+			"waiting for virtual machine (ID:%d) to be in state %s: %s", vmc.ID, strings.Join(finalStrs, " "), err)
 	}
 
 	// Check that disk has new size
@@ -222,11 +240,17 @@ func vmNICAttach(ctx context.Context, vmc *goca.VMController, timeout time.Durat
 		return -1, fmt.Errorf("can't attach network with ID:%d: %s\n", networkID, err)
 	}
 
-	// wait before checking NIC
-	_, err = waitForVMState(ctx, vmc, timeout, vmNICUpdateReadyStates...)
+	// wait before checking NIC list
+	// final states ar added to transient one in case of slow cloud
+	transient := vmNICTransientStates
+	transient.Append(vmNICUpdateReadyStates)
+	finalStrs := vmNICUpdateReadyStates.ToStrings()
+	stateConf := NewVMUpdateStateConf(timeout, transient.ToStrings(), finalStrs)
+
+	_, err = waitForVMStates(ctx, vmc, stateConf)
 	if err != nil {
 		return -1, fmt.Errorf(
-			"waiting for virtual machine (ID:%d) to be in state %s: %s", vmc.ID, strings.Join(vmNICUpdateReadyStates, " "), err)
+			"waiting for virtual machine (ID:%d) to be in state %s: %s", vmc.ID, strings.Join(finalStrs, " "), err)
 	}
 
 	// compare NIC list to check that a new NIC is attached
@@ -297,11 +321,17 @@ func vmNICDetach(ctx context.Context, vmc *goca.VMController, timeout time.Durat
 		return fmt.Errorf("can't detach NIC %d: %s\n", nicID, err)
 	}
 
-	// wait before checking NIC
-	_, err = waitForVMState(ctx, vmc, timeout, vmNICUpdateReadyStates...)
+	// wait before checking NIC list
+	// final states ar added to transient one in case of slow cloud
+	transient := vmNICTransientStates
+	transient.Append(vmNICUpdateReadyStates)
+	finalStrs := vmNICUpdateReadyStates.ToStrings()
+	stateConf := NewVMUpdateStateConf(timeout, transient.ToStrings(), finalStrs)
+
+	_, err = waitForVMStates(ctx, vmc, stateConf)
 	if err != nil {
 		return fmt.Errorf(
-			"waiting for virtual machine (ID:%d) to be in state %s: %s", vmc.ID, strings.Join(vmNICUpdateReadyStates, " "), err)
+			"waiting for virtual machine (ID:%d) to be in state %s: %s", vmc.ID, strings.Join(finalStrs, " "), err)
 	}
 
 	// Check that NIC is detached

--- a/opennebula/helpers_vm_state.go
+++ b/opennebula/helpers_vm_state.go
@@ -1,0 +1,174 @@
+package opennebula
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/OpenNebula/one/src/oca/go/src/goca"
+	"github.com/OpenNebula/one/src/oca/go/src/goca/schemas/vm"
+	vmk "github.com/OpenNebula/one/src/oca/go/src/goca/schemas/vm/keys"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+var (
+	// States management
+
+	// Creation
+	vmCreateTransientStates = VMStates{
+		States: []vm.State{vm.Pending},
+		LCMs:   []vm.LCMState{vm.Prolog, vm.Boot},
+	}
+
+	// Deletion: terminate the VM
+	vmDeleteReadyStates = VMStates{
+		States: []vm.State{vm.Hold, vm.Poweroff, vm.Stopped, vm.Undeployed, vm.Suspended, vm.Done},
+		LCMs:   []vm.LCMState{vm.Running},
+	}
+
+	vmDeleteTransientStates = VMStates{
+		LCMs: []vm.LCMState{vm.Shutdown, vm.Epilog},
+	}
+
+	// Update: when the VM is powered off
+	vmPowerOffTransientStates = VMStates{
+		LCMs: []vm.LCMState{vm.ShutdownPoweroff},
+	}
+
+	vmResizeTransientStates = VMStates{
+		States: []vm.State{vm.Active},
+		LCMs:   []vm.LCMState{vm.HotplugResize},
+	}
+
+	vmResizeReadyStates = VMStates{
+		States: []vm.State{vm.Poweroff, vm.Undeployed},
+	}
+
+	// Disk and NIC updates
+	vmDiskUpdateReadyStates = VMStates{
+		States: []vm.State{vm.Poweroff},
+		LCMs:   []vm.LCMState{vm.Running},
+	}
+
+	vmNICUpdateReadyStates = vmDiskUpdateReadyStates
+
+	vmDiskResizeReadyStates = VMStates{
+		States: []vm.State{vm.Poweroff, vm.Undeployed},
+		LCMs:   []vm.LCMState{vm.Running},
+	}
+
+	vmDiskTransientStates = VMStates{
+		LCMs: []vm.LCMState{vm.Hotplug, vm.HotplugPrologPoweroff, vm.HotplugEpilogPoweroff, vm.DiskResize, vm.DiskResizePoweroff, vm.DiskResizeUndeployed},
+	}
+
+	vmNICTransientStates = VMStates{
+		LCMs: []vm.LCMState{vm.HotplugNic, vm.HotplugNicPoweroff},
+	}
+)
+
+func NewVMStateConf(timeout time.Duration, target, pending []string) resource.StateChangeConf {
+	return resource.StateChangeConf{
+		Delay:      10 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+}
+
+func NewVMUpdateStateConf(timeout time.Duration, target, pending []string) resource.StateChangeConf {
+	return resource.StateChangeConf{
+		Delay:      5 * time.Second,
+		MinTimeout: 2 * time.Second,
+	}
+}
+
+type VMStates struct {
+	States []vm.State
+	LCMs   []vm.LCMState
+}
+
+func NewVMState(states ...vm.State) VMStates {
+	vmStates := VMStates{}
+	copy(vmStates.States, states)
+	return vmStates
+}
+
+func NewVMLCMState(lcms ...vm.LCMState) VMStates {
+	vmStates := VMStates{}
+	copy(vmStates.LCMs, lcms)
+	return vmStates
+}
+
+func (s VMStates) ToStrings() []string {
+	ret := make([]string, len(s.States)+len(s.LCMs), 0)
+	for _, state := range s.States {
+		ret = append(ret, fmt.Sprintf("%s:%s", state, vm.LcmInit))
+	}
+	for _, lcm := range s.States {
+		ret = append(ret, fmt.Sprintf("%s:%s", vm.Active, lcm))
+	}
+	return ret
+}
+
+func (s VMStates) Append(states VMStates) VMStates {
+	s.States = append(s.States, states.States...)
+	s.LCMs = append(s.LCMs, states.LCMs...)
+	return s
+}
+
+func waitForVMStates(ctx context.Context, vmc *goca.VMController, stateChangeConf resource.StateChangeConf) (interface{}, error) {
+
+	stateChangeConf.Refresh = func() (interface{}, string, error) {
+
+		log.Println("Refreshing VM state...")
+
+		vmInfos, err := vmc.Info(false)
+		if err != nil {
+			if NoExists(err) {
+				// Do not return an error here as it is excpected if the VM is already in DONE state
+				// after its destruction
+				return nil, "err_not_found", nil
+			}
+			return nil, "err", err
+		}
+
+		vmState, vmLcmState, err := vmInfos.State()
+		if err != nil {
+			return vmInfos, "err_unknown_state", err
+		}
+		log.Printf("VM (ID:%d, name:%s) is currently in state %s and in LCM state %s", vmInfos.ID, vmInfos.Name, vmState.String(), vmLcmState.String())
+
+		vmFullState := fmt.Sprintf("%s:%s", vmState, vmLcmState)
+
+		// In case we are in some failure state, we try to retrieve more error informations from the vm user template
+		if vmState == vm.Active &&
+			vmLcmState == vm.BootFailure ||
+			vmLcmState == vm.PrologFailure ||
+			vmLcmState == vm.EpilogFailure {
+			vmerr, _ := vmInfos.UserTemplate.Get(vmk.Error)
+			return vmInfos, vmFullState, fmt.Errorf("VM (ID:%d) entered fail state, error: %s", vmInfos.ID, vmerr)
+		}
+
+		return vmInfos, vmFullState, nil
+	}
+
+	return stateChangeConf.WaitForStateContext(ctx)
+
+}
+
+func waitForVMsStates(ctx context.Context, c *goca.Controller, vmIDs []int, stateChangeConf resource.StateChangeConf) ([]interface{}, []error) {
+
+	errors := make([]error, 0)
+	vmsInfos := make([]interface{}, 0)
+
+	for _, id := range vmIDs {
+		vmInfo, err := waitForVMStates(ctx, c.VM(id), stateChangeConf)
+		if vmInfo != nil {
+			vmsInfos = append(vmsInfos, vmInfo)
+		}
+		if err != nil {
+			errors = append(errors, err)
+		}
+	}
+
+	return vmsInfos, errors
+}

--- a/opennebula/resource_opennebula_virtual_machine.go
+++ b/opennebula/resource_opennebula_virtual_machine.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/OpenNebula/one/src/oca/go/src/goca"
@@ -21,13 +20,10 @@ import (
 )
 
 var (
-	vmDiskOnChangeValues    = []string{"RECREATE", "SWAP"}
-	vmDiskUpdateReadyStates = []string{"RUNNING", "POWEROFF"}
-	vmDiskResizeReadyStates = []string{"RUNNING", "POWEROFF", "UNDEPLOYED"}
-	vmNICUpdateReadyStates  = vmDiskUpdateReadyStates
-	vmDeleteReadyStates     = []string{"RUNNING", "HOLD", "POWEROFF", "STOPPED", "UNDEPLOYED", "SUSPENDED"}
-	defaultVMMinTimeout     = 3
-	defaultVMTimeout        = time.Duration(defaultVMMinTimeout) * time.Minute
+	vmDiskOnChangeValues = []string{"RECREATE", "SWAP"}
+
+	defaultVMTimeoutMin = 1
+	defaultVMTimeout    = time.Duration(defaultVMTimeoutMin) * time.Minute
 )
 
 func resourceOpennebulaVirtualMachine() *schema.Resource {
@@ -364,25 +360,33 @@ func resourceOpennebulaVirtualMachineCreate(ctx context.Context, d *schema.Resou
 	d.SetId(fmt.Sprintf("%v", vmID))
 	vmc := controller.VM(vmID)
 
-	expectedState := "RUNNING"
+	final := NewVMLCMState(vm.Running)
 	if d.Get("pending").(bool) {
-		expectedState = "HOLD"
+		final = NewVMState(vm.State(vm.Running))
 	}
 
+	// wait for the VM to be started and ready
 	timeout := time.Duration(d.Get("timeout").(int)) * time.Minute
 	if timeout == defaultVMTimeout {
 		timeout = d.Timeout(schema.TimeoutCreate)
 	}
-	_, err = waitForVMState(ctx, vmc, timeout, expectedState)
+
+	stateConf := NewVMStateConf(timeout,
+		vmCreateTransientStates.ToStrings(),
+		final.ToStrings(),
+	)
+
+	_, err = waitForVMStates(ctx, vmc, stateConf)
 	if err != nil {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
-			Summary:  fmt.Sprintf("Failed to wait virtual machine to be in %s state", expectedState),
+			Summary:  fmt.Sprintf("Failed to wait virtual machine to be in %s state", final.ToStrings()),
 			Detail:   err.Error(),
 		})
 		return diags
 	}
 
+	// finalize the VM configuration
 	//Set the permissions on the VM if it was defined, otherwise use the UMASK in OpenNebula
 	if perms, ok := d.GetOk("permissions"); ok {
 		err = vmc.Chmod(permissionUnix(perms.(string)))
@@ -1393,7 +1397,17 @@ func resourceOpennebulaVirtualMachineUpdateCustom(ctx context.Context, d *schema
 				})
 				return diags
 			}
-			_, err = waitForVMState(ctx, vmc, timeout, "POWEROFF")
+
+			// wait for the VM to be powered off
+			// RUNNING state is added to transient one in case of slow cloud
+			transient := vmPowerOffTransientStates
+			transient.LCMs = append(transient.LCMs, vm.Running)
+			stateConf := NewVMUpdateStateConf(timeout,
+				transient.ToStrings(),
+				NewVMState(vm.Poweroff).ToStrings(),
+			)
+
+			_, err = waitForVMStates(ctx, vmc, stateConf)
 			if err != nil {
 				diags = append(diags, diag.Diagnostic{
 					Severity: diag.Error,
@@ -1430,6 +1444,21 @@ func resourceOpennebulaVirtualMachineUpdateCustom(ctx context.Context, d *schema
 			return diags
 		}
 
+		// wait for the VM to be back in POWEROFF state
+		transientStrs := NewVMLCMState(vm.HotplugResize).ToStrings()
+		finalStrs := NewVMState(vm.Poweroff, vm.Undeployed).ToStrings()
+		stateConf := NewVMUpdateStateConf(timeout, transientStrs, finalStrs)
+
+		_, err = waitForVMStates(ctx, vmc, stateConf)
+		if err != nil {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  fmt.Sprintf("Failed to wait virtual machine to be in %s state", strings.Join(finalStrs, " ")),
+				Detail:   err.Error(),
+			})
+			return diags
+		}
+
 		if vmRequireShutdown {
 			err = vmc.Resume()
 			if err != nil {
@@ -1440,7 +1469,13 @@ func resourceOpennebulaVirtualMachineUpdateCustom(ctx context.Context, d *schema
 				})
 				return diags
 			}
-			_, err = waitForVMState(ctx, vmc, timeout, "RUNNING")
+			stateConf := NewVMUpdateStateConf(timeout,
+				NewVMLCMState(vm.BootPoweroff).ToStrings(),
+				NewVMLCMState(vm.Running).ToStrings(),
+			)
+
+			// wait for the VM to be back in RUNNING state
+			_, err = waitForVMStates(ctx, vmc, stateConf)
 			if err != nil {
 				diags = append(diags, diag.Diagnostic{
 					Severity: diag.Error,
@@ -1460,7 +1495,18 @@ func resourceOpennebulaVirtualMachineUpdateCustom(ctx context.Context, d *schema
 			timeout = d.Timeout(schema.TimeoutUpdate)
 		}
 
-		_, err = waitForVMState(ctx, vmc, timeout, "RUNNING")
+		// wait for the VM to be RUNNING to avoid action failures
+		// RUNNING state is added to transient one in case of slow cloud
+		transientStrs := NewVMLCMState(vm.Running).
+			Append(vmDiskTransientStates).
+			Append(vmNICTransientStates).ToStrings()
+		finalStrs := NewVMLCMState(vm.Running).ToStrings()
+		stateConf := NewVMUpdateStateConf(timeout,
+			transientStrs,
+			finalStrs,
+		)
+
+		_, err = waitForVMStates(ctx, vmc, stateConf)
 		if err != nil {
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,
@@ -1482,7 +1528,11 @@ func resourceOpennebulaVirtualMachineUpdateCustom(ctx context.Context, d *schema
 			return diags
 		}
 
-		_, err = waitForVMState(ctx, vmc, timeout, "RUNNING")
+		// wait for the VM to be RUNNING after update
+		stateConf = NewVMUpdateStateConf(timeout,
+			[]string{},
+			finalStrs,
+		)
 		if err != nil {
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,
@@ -1867,14 +1917,21 @@ func resourceOpennebulaVirtualMachineDelete(ctx context.Context, d *schema.Resou
 	// wait state to be ready
 	timeout := time.Duration(d.Get("timeout").(int)) * time.Minute
 	if timeout == defaultVMTimeout {
-		timeout = d.Timeout(schema.TimeoutUpdate)
+		timeout = d.Timeout(schema.TimeoutDelete)
 	}
 
-	_, err = waitForVMState(ctx, vmc, timeout, vmDeleteReadyStates...)
+	// wait for the VM to be in a state that permit it to be deleted
+	finalStrs := vmDeleteReadyStates.ToStrings()
+	stateConf := NewVMUpdateStateConf(timeout,
+		[]string{},
+		finalStrs,
+	)
+
+	_, err = waitForVMStates(ctx, vmc, stateConf)
 	if err != nil {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
-			Summary:  fmt.Sprintf("Failed to wait virtual machine to be in %s state", strings.Join(vmDeleteReadyStates, " ")),
+			Summary:  fmt.Sprintf("Failed to wait virtual machine to be in %s state", strings.Join(finalStrs, " ")),
 			Detail:   err.Error(),
 		})
 		return diags
@@ -1885,23 +1942,25 @@ func resourceOpennebulaVirtualMachineDelete(ctx context.Context, d *schema.Resou
 	} else {
 		err = vmc.Terminate()
 	}
+
+	// wait for the VM to be powered off
+	// RUNNING state is added to transient one in case of slow cloud
+	transientStrs := NewVMLCMState(vm.Running).
+		Append(vmDeleteTransientStates).
+		ToStrings()
+
+	stateConf = NewVMStateConf(timeout,
+		transientStrs,
+		NewVMState(vm.Done).ToStrings(),
+	)
+
+	ret, err := waitForVMStates(ctx, vmc, stateConf)
 	if err != nil {
-		diags = append(diags, diag.Diagnostic{
-			Severity: diag.Error,
-			Summary:  "Failed to terminate",
-			Detail:   err.Error(),
-		})
-		return diags
-	}
 
-	ret, err := waitForVMState(ctx, vmc, timeout, "DONE")
-	if err != nil {
+		log.Printf("[WARN] waitForVMStates: %s\n", err)
 
-		log.Printf("[WARN] %s\n", err)
-
-		// Retry if timeout not reached
-		_, ok := err.(*resource.TimeoutError)
-		if !ok && ret != nil {
+		// retry
+		if ret != nil {
 
 			vmInfos, _ := ret.(*vm.VM)
 			vmState, vmLcmState, _ := vmInfos.State()
@@ -1914,6 +1973,7 @@ func resourceOpennebulaVirtualMachineDelete(ctx context.Context, d *schema.Resou
 				} else {
 					err = vmc.Terminate()
 				}
+
 				if err != nil {
 					diags = append(diags, diag.Diagnostic{
 						Severity: diag.Error,
@@ -1923,7 +1983,7 @@ func resourceOpennebulaVirtualMachineDelete(ctx context.Context, d *schema.Resou
 					return diags
 				}
 
-				_, err = waitForVMState(ctx, vmc, timeout, "DONE")
+				_, err = waitForVMStates(ctx, vmc, stateConf)
 				if err != nil {
 					diags = append(diags, diag.Diagnostic{
 						Severity: diag.Error,
@@ -1943,84 +2003,21 @@ func resourceOpennebulaVirtualMachineDelete(ctx context.Context, d *schema.Resou
 					return diags
 				}
 			}
+		} else {
+			if err != nil {
+				diags = append(diags, diag.Diagnostic{
+					Severity: diag.Error,
+					Summary:  "Failed to wait virtual machine to be in DONE state",
+					Detail:   err.Error(),
+				})
+				return diags
+			}
 		}
+
 	}
 
 	log.Printf("[INFO] Successfully terminated VM\n")
 	return nil
-}
-
-func waitForVMState(ctx context.Context, vmc *goca.VMController, timeout time.Duration, states ...string) (interface{}, error) {
-
-	stateConf := &resource.StateChangeConf{
-		Pending: []string{"anythingelse"},
-		Target:  states,
-		Refresh: func() (interface{}, string, error) {
-
-			log.Println("Refreshing VM state...")
-
-			// TODO: fix it after 5.10 release
-			// Force the "decrypt" bool to false to keep ONE 5.8 behavior
-			vmInfos, err := vmc.Info(false)
-			if err != nil {
-				if NoExists(err) {
-					// Do not return an error here as it is excpected if the VM is already in DONE state
-					// after its destruction
-					return vmInfos, "notfound", nil
-				}
-				return vmInfos, "", err
-			}
-
-			vmState, vmLcmState, err := vmInfos.State()
-			if err != nil {
-				return vmInfos, "", err
-			}
-			log.Printf("VM (ID:%d, name:%s) is currently in state %s and in LCM state %s", vmInfos.ID, vmInfos.Name, vmState.String(), vmLcmState.String())
-
-			switch vmState {
-
-			case vm.Done, vm.Hold, vm.Suspended, vm.Stopped, vm.Poweroff, vm.Undeployed:
-				return vmInfos, vmState.String(), nil
-			case vm.Active:
-				switch vmLcmState {
-				case vm.Running:
-					return vmInfos, vmLcmState.String(), nil
-				case vm.BootFailure, vm.PrologFailure, vm.EpilogFailure:
-					vmerr, _ := vmInfos.UserTemplate.Get(vmk.Error)
-					return vmInfos, vmLcmState.String(), fmt.Errorf("VM (ID:%d) entered fail state, error: %s", vmInfos.ID, vmerr)
-				default:
-					return vmInfos, "anythingelse", nil
-				}
-			default:
-				return vmInfos, "anythingelse", nil
-			}
-
-		},
-		Timeout:    timeout,
-		Delay:      10 * time.Second,
-		MinTimeout: 3 * time.Second,
-	}
-
-	return stateConf.WaitForStateContext(ctx)
-
-}
-
-func waitForVMsStates(ctx context.Context, c *goca.Controller, vmIDs []int, timeout time.Duration, states ...string) ([]interface{}, []error) {
-
-	errors := make([]error, 0)
-	vmsInfos := make([]interface{}, 0)
-
-	for _, id := range vmIDs {
-		vmInfo, err := waitForVMState(ctx, c.VM(id), timeout, states...)
-		if vmInfo != nil {
-			vmsInfos = append(vmsInfos, vmInfo)
-		}
-		if err != nil {
-			errors = append(errors, err)
-		}
-	}
-
-	return vmsInfos, errors
 }
 
 func generateVm(d *schema.ResourceData, tplContext *dyn.Vector) (*vm.Template, error) {

--- a/opennebula/resource_opennebula_virtual_router_instance_template.go
+++ b/opennebula/resource_opennebula_virtual_router_instance_template.go
@@ -72,7 +72,7 @@ func customVirtualRouterInstanceTemplateRead(ctx context.Context, d *schema.Reso
 			Summary:  "Misconfigured virtual router instance template",
 			Detail:   fmt.Sprintf("the template (ID:%d) doesn't contains the VROUTER=YES tag", tpl.ID),
 		})
-
+		return diags
 	}
 
 	return nil

--- a/opennebula/shared_schemas.go
+++ b/opennebula/shared_schemas.go
@@ -34,7 +34,7 @@ func commonVMSchemas() map[string]*schema.Schema {
 			"timeout": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Default:     defaultVMMinTimeout,
+				Default:     defaultVMTimeoutMin,
 				Description: "Timeout (in minutes) within resource should be available. Default: 3 minutes",
 				Deprecated:  "Native terraform timeout facilities should be used instead",
 			},


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

Rework state management for virtual machines and virtual router instances (they also are custom VMs).
- Rework waitForVMState method: embed less details to be more configurable, return state string by default, use "full" state (i.e. the state string is formatted like this: "state_string:lcm_state_string" ) instead of mixing states and LCM states
- use more "Pending" states, so the provider expect more transitory states and fails less easily
- add "Final" states to "Pending" states for fix the error from #132 in case of slow cloud (the VM was in RUNNING state more than 10secs before changing it's state)

### References

Close #132 

### New or Affected Resource(s)

<!--- Please list the new or affected resources and data sources. --->

- opennebula_virtual_machine
- opennebula_virtual_router_instance

### Checklist

<!--- Please check you didn't forgot a step to help us merging this PR. --->

- [ ] I have created an issue and I have mentioned it in `References`
- [ ] My code follows the style guidelines of this project (use `go fmt`)
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the unit tests and they pass succesfuly
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation (if needed)
- [ ] I have updated the changelog file
