### PR TITLE
B-132: wait vm state rework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ BUG FIXES:
 * provider: Fail on bad credentials (#288)
 * data/opennebula_template: Fix error when `cpu`, `vcpu` or `memory` undefined (#284)
 * resources/opennebula_virtual_machine: fix missing NIC generation (#289)
+* resources/opennebula_virtual_machine: fix VM state management failures (#132)
 
 ## 0.5.0 (June 7th, 2022)
 

--- a/opennebula/helpers_vm.go
+++ b/opennebula/helpers_vm.go
@@ -48,11 +48,17 @@ func vmDiskAttach(ctx context.Context, vmc *goca.VMController, timeout time.Dura
 
 	}
 
-	// wait before checking disk
-	_, err = waitForVMState(ctx, vmc, timeout, vmDiskUpdateReadyStates...)
+	// wait before checking disk list
+	// final states ar added to transient one in case of slow cloud
+	transient := vmDiskTransientStates
+	transient.Append(vmDiskUpdateReadyStates)
+	finalStrs := vmDiskUpdateReadyStates.ToStrings()
+	stateConf := NewVMUpdateStateConf(timeout, transient.ToStrings(), finalStrs)
+
+	_, err = waitForVMStates(ctx, vmc, stateConf)
 	if err != nil {
 		return -1, fmt.Errorf(
-			"waiting for virtual machine (ID:%d) to be in state %s: %s", vmc.ID, strings.Join(vmDiskUpdateReadyStates, " "), err)
+			"waiting for virtual machine (ID:%d) to be in state %s: %s", vmc.ID, strings.Join(finalStrs, ","), err)
 	}
 
 	// compare disk list to check that a new disk is attached
@@ -122,11 +128,17 @@ func vmDiskDetach(ctx context.Context, vmc *goca.VMController, timeout time.Dura
 		return fmt.Errorf("can't detach disk %d: %s\n", diskID, err)
 	}
 
-	// wait before checking disk
-	_, err = waitForVMState(ctx, vmc, timeout, vmDiskUpdateReadyStates...)
+	// wait before checking disk list
+	// final states ar added to transient one in case of slow cloud
+	transient := vmDiskTransientStates.
+		Append(vmDiskUpdateReadyStates)
+	finalStrs := vmDiskUpdateReadyStates.ToStrings()
+	stateConf := NewVMUpdateStateConf(timeout, transient.ToStrings(), finalStrs)
+
+	_, err = waitForVMStates(ctx, vmc, stateConf)
 	if err != nil {
 		return fmt.Errorf(
-			"waiting for virtual machine (ID:%d) to be in state %s: %s", vmc.ID, strings.Join(vmDiskUpdateReadyStates, " "), err)
+			"waiting for virtual machine (ID:%d) to be in state %s: %s", vmc.ID, strings.Join(finalStrs, ","), err)
 	}
 
 	// Check that disk is detached
@@ -168,11 +180,17 @@ func vmDiskResize(ctx context.Context, vmc *goca.VMController, timeout time.Dura
 		return fmt.Errorf("can't resize image with Disk ID:%d: %s\n", diskID, err)
 	}
 
-	// wait before checking disk
-	_, err = waitForVMState(ctx, vmc, timeout, vmDiskResizeReadyStates...)
+	// wait before checking disk list
+	// final states ar added to transient one in case of slow cloud
+	transient := vmDiskTransientStates
+	transient.Append(vmDiskResizeReadyStates)
+	finalStrs := vmDiskResizeReadyStates.ToStrings()
+	stateConf := NewVMUpdateStateConf(timeout, transient.ToStrings(), finalStrs)
+
+	_, err = waitForVMStates(ctx, vmc, stateConf)
 	if err != nil {
 		return fmt.Errorf(
-			"waiting for virtual machine (ID:%d) to be in state %s: %s", vmc.ID, strings.Join(vmDiskUpdateReadyStates, " "), err)
+			"waiting for virtual machine (ID:%d) to be in state %s: %s", vmc.ID, strings.Join(finalStrs, ","), err)
 	}
 
 	// Check that disk has new size
@@ -222,11 +240,17 @@ func vmNICAttach(ctx context.Context, vmc *goca.VMController, timeout time.Durat
 		return -1, fmt.Errorf("can't attach network with ID:%d: %s\n", networkID, err)
 	}
 
-	// wait before checking NIC
-	_, err = waitForVMState(ctx, vmc, timeout, vmNICUpdateReadyStates...)
+	// wait before checking NIC list
+	// final states ar added to transient one in case of slow cloud
+	transient := vmNICTransientStates
+	transient.Append(vmNICUpdateReadyStates)
+	finalStrs := vmNICUpdateReadyStates.ToStrings()
+	stateConf := NewVMUpdateStateConf(timeout, transient.ToStrings(), finalStrs)
+
+	_, err = waitForVMStates(ctx, vmc, stateConf)
 	if err != nil {
 		return -1, fmt.Errorf(
-			"waiting for virtual machine (ID:%d) to be in state %s: %s", vmc.ID, strings.Join(vmNICUpdateReadyStates, " "), err)
+			"waiting for virtual machine (ID:%d) to be in state %s: %s", vmc.ID, strings.Join(finalStrs, ","), err)
 	}
 
 	// compare NIC list to check that a new NIC is attached
@@ -297,11 +321,17 @@ func vmNICDetach(ctx context.Context, vmc *goca.VMController, timeout time.Durat
 		return fmt.Errorf("can't detach NIC %d: %s\n", nicID, err)
 	}
 
-	// wait before checking NIC
-	_, err = waitForVMState(ctx, vmc, timeout, vmNICUpdateReadyStates...)
+	// wait before checking NIC list
+	// final states ar added to transient one in case of slow cloud
+	transient := vmNICTransientStates
+	transient.Append(vmNICUpdateReadyStates)
+	finalStrs := vmNICUpdateReadyStates.ToStrings()
+	stateConf := NewVMUpdateStateConf(timeout, transient.ToStrings(), finalStrs)
+
+	_, err = waitForVMStates(ctx, vmc, stateConf)
 	if err != nil {
 		return fmt.Errorf(
-			"waiting for virtual machine (ID:%d) to be in state %s: %s", vmc.ID, strings.Join(vmNICUpdateReadyStates, " "), err)
+			"waiting for virtual machine (ID:%d) to be in state %s: %s", vmc.ID, strings.Join(finalStrs, ","), err)
 	}
 
 	// Check that NIC is detached

--- a/opennebula/helpers_vm.go
+++ b/opennebula/helpers_vm.go
@@ -289,13 +289,10 @@ func vmNICAttach(ctx context.Context, vmc *goca.VMController, timeout time.Durat
 			for _, pair := range nicTpl.Pairs {
 
 				value, err := nic.GetStr(pair.Key())
-				if err != nil {
-
-				}
-
-				if value != pair.Value {
+				if err != nil || value != pair.Value {
 					continue loop
 				}
+
 			}
 
 			attachedNIC = &updatedNICs[i]

--- a/opennebula/helpers_vm_state.go
+++ b/opennebula/helpers_vm_state.go
@@ -1,0 +1,197 @@
+package opennebula
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/OpenNebula/one/src/oca/go/src/goca"
+	"github.com/OpenNebula/one/src/oca/go/src/goca/schemas/vm"
+	vmk "github.com/OpenNebula/one/src/oca/go/src/goca/schemas/vm/keys"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+var (
+	// VM states
+
+	// Ready states: the possible states the VM should be in to be able to trigger the action
+	// Transient states: when the action has been triggered, the VM will be in a set of transient states.
+	// Sometimes these collections of state are used:
+	// - before triggering the action to ensure it won't fail
+	// - after triggering the action to control that the VM will go back in an expected state
+
+	// Creation
+	vmCreateTransientStates = VMStates{
+		States: []vm.State{vm.Pending},
+		LCMs:   []vm.LCMState{vm.Prolog, vm.Boot},
+	}
+
+	// Deletion: terminate the VM
+	vmDeleteReadyStates = VMStates{
+		States: []vm.State{vm.Hold, vm.Poweroff, vm.Stopped, vm.Undeployed, vm.Suspended, vm.Done},
+		LCMs:   []vm.LCMState{vm.Running},
+	}
+
+	vmDeleteTransientStates = VMStates{
+		LCMs: []vm.LCMState{vm.Shutdown, vm.Epilog},
+	}
+
+	// Update: when the VM is powered off
+	vmPowerOffTransientStates = VMStates{
+		LCMs: []vm.LCMState{vm.ShutdownPoweroff},
+	}
+
+	// Update: VM resize
+	vmResizeTransientStates = VMStates{
+		LCMs: []vm.LCMState{vm.HotplugResize},
+	}
+
+	vmResizeReadyStates = VMStates{
+		States: []vm.State{vm.Poweroff, vm.Undeployed},
+	}
+
+	// Disk and NIC updates
+	vmDiskUpdateReadyStates = VMStates{
+		States: []vm.State{vm.Poweroff},
+		LCMs:   []vm.LCMState{vm.Running},
+	}
+
+	vmNICUpdateReadyStates = vmDiskUpdateReadyStates
+
+	vmDiskResizeReadyStates = VMStates{
+		States: []vm.State{vm.Poweroff, vm.Undeployed},
+		LCMs:   []vm.LCMState{vm.Running},
+	}
+
+	vmDiskTransientStates = VMStates{
+		LCMs: []vm.LCMState{vm.Hotplug, vm.HotplugPrologPoweroff, vm.HotplugEpilogPoweroff, vm.DiskResize, vm.DiskResizePoweroff, vm.DiskResizeUndeployed},
+	}
+
+	vmNICTransientStates = VMStates{
+		LCMs: []vm.LCMState{vm.HotplugNic, vm.HotplugNicPoweroff},
+	}
+)
+
+// VMStates represents a collection of VM states
+type VMStates struct {
+	States []vm.State
+	LCMs   []vm.LCMState
+}
+
+func NewVMState(states ...vm.State) VMStates {
+	vmStates := VMStates{
+		States: make([]vm.State, len(states)),
+	}
+	copy(vmStates.States, states)
+	return vmStates
+}
+
+func NewVMLCMState(lcms ...vm.LCMState) VMStates {
+	vmStates := VMStates{
+		LCMs: make([]vm.LCMState, len(lcms)),
+	}
+	copy(vmStates.LCMs, lcms)
+	return vmStates
+}
+
+func (s VMStates) Append(states VMStates) VMStates {
+	s.States = append(s.States, states.States...)
+	s.LCMs = append(s.LCMs, states.LCMs...)
+	return s
+}
+
+func (s VMStates) ToStrings() []string {
+	ret := make([]string, 0, len(s.States)+len(s.LCMs))
+	for _, state := range s.States {
+		ret = append(ret, state.String())
+	}
+	for _, lcm := range s.LCMs {
+		ret = append(ret, lcm.String())
+	}
+	return ret
+}
+
+// NewVMStateConf initialize a state change struct
+func NewVMStateConf(timeout time.Duration, pending, target []string) resource.StateChangeConf {
+	return resource.StateChangeConf{
+		Pending:    pending,
+		Target:     target,
+		Timeout:    timeout,
+		Delay:      10 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+}
+
+// NewVMUpdateStateConf initialize a state change struct
+func NewVMUpdateStateConf(timeout time.Duration, pending, target []string) resource.StateChangeConf {
+	return resource.StateChangeConf{
+		Pending:    pending,
+		Target:     target,
+		Timeout:    timeout,
+		Delay:      5 * time.Second,
+		MinTimeout: 2 * time.Second,
+	}
+}
+
+// waitForVMStates wait for a VM to reach some states
+func waitForVMStates(ctx context.Context, vmc *goca.VMController, stateChangeConf resource.StateChangeConf) (interface{}, error) {
+
+	stateChangeConf.Refresh = func() (interface{}, string, error) {
+
+		log.Println("Refreshing VM state...")
+
+		vmInfos, err := vmc.Info(false)
+		if err != nil {
+			if NoExists(err) {
+				// Do not return an error here as it is excpected if the VM is already in DONE state
+				// after its destruction
+				return nil, "err_not_found", nil
+			}
+			return nil, "err", err
+		}
+
+		vmState, vmLCMState, err := vmInfos.State()
+		if err != nil {
+			return vmInfos, "err_unknown_state", err
+		}
+		log.Printf("VM (ID:%d, name:%s) is currently in state %s and in LCM state %s", vmInfos.ID, vmInfos.Name, vmState.String(), vmLCMState.String())
+
+		if vmState == vm.Active {
+
+			// In case we are in some failure state, we try to retrieve more error informations from the vm user template
+			if vmLCMState == vm.BootFailure ||
+				vmLCMState == vm.PrologFailure ||
+				vmLCMState == vm.EpilogFailure {
+				vmerr, _ := vmInfos.UserTemplate.Get(vmk.Error)
+				return vmInfos, vmLCMState.String(), fmt.Errorf("VM (ID:%d) entered fail state, error: %s", vmInfos.ID, vmerr)
+			}
+
+			return vmInfos, vmLCMState.String(), nil
+
+		}
+
+		return vmInfos, vmState.String(), nil
+	}
+
+	return stateChangeConf.WaitForStateContext(ctx)
+
+}
+
+func waitForVMsStates(ctx context.Context, c *goca.Controller, vmIDs []int, stateChangeConf resource.StateChangeConf) ([]interface{}, []error) {
+
+	errors := make([]error, 0)
+	vmsInfos := make([]interface{}, 0)
+
+	for _, id := range vmIDs {
+		vmInfo, err := waitForVMStates(ctx, c.VM(id), stateChangeConf)
+		if vmInfo != nil {
+			vmsInfos = append(vmsInfos, vmInfo)
+		}
+		if err != nil {
+			errors = append(errors, err)
+		}
+	}
+
+	return vmsInfos, errors
+}

--- a/opennebula/helpers_vr.go
+++ b/opennebula/helpers_vr.go
@@ -11,9 +11,13 @@ import (
 
 	"github.com/OpenNebula/one/src/oca/go/src/goca"
 	"github.com/OpenNebula/one/src/oca/go/src/goca/schemas/shared"
+	"github.com/OpenNebula/one/src/oca/go/src/goca/schemas/vm"
 )
 
-var vrNICAddInstancesStates = []string{"RUNNING", "POWEROFF", "DONE"}
+var vrNICAddInstancesStates = VMStates{
+	States: []vm.State{vm.Poweroff, vm.Done},
+	LCMs:   []vm.LCMState{vm.Running},
+}
 
 // vrNICAttach is an helper that synchronously attach a nic
 func vrNICAttach(ctx context.Context, timeout time.Duration, controller *goca.Controller, vrID int, nicTpl *shared.NIC) (int, error) {
@@ -42,14 +46,24 @@ func vrNICAttach(ctx context.Context, timeout time.Duration, controller *goca.Co
 
 	// check if virtual router machines are in transient states
 	if len(vrInfos.VMs.ID) > 0 {
-		_, errs := waitForVMsStates(ctx, controller, vrInfos.VMs.ID, timeout, vmNICUpdateReadyStates...)
+
+		transient := vmNICTransientStates
+		transient.Append(vmNICUpdateReadyStates)
+		finalStrs := vmNICUpdateReadyStates.ToStrings()
+
+		stateConf := NewVMUpdateStateConf(timeout,
+			transient.ToStrings(),
+			finalStrs,
+		)
+
+		_, errs := waitForVMsStates(ctx, controller, vrInfos.VMs.ID, stateConf)
 		if len(errs) > 0 {
 			var fullErr string
 			for _, err := range errs {
 				fullErr += fmt.Sprintf("\nVM error: %s\n", err.Error())
 			}
 			return -1, fmt.Errorf(
-				"Virtual router waiting for virtual machines to be in state %s: %s", strings.Join(vmNICUpdateReadyStates, " "), fullErr)
+				"Virtual router waiting for virtual machines to be in state %s: %s", strings.Join(finalStrs, ","), fullErr)
 		}
 	}
 
@@ -150,16 +164,27 @@ func vrNICDetach(ctx context.Context, timeout time.Duration, controller *goca.Co
 		return err
 	}
 
-	// check if virtual router machines are in transient states
 	if len(vrInfos.VMs.ID) > 0 {
-		_, errs := waitForVMsStates(ctx, controller, vrInfos.VMs.ID, timeout, vrNICAddInstancesStates...)
+
+		// check if virtual router machines are in transient states
+		// If one of the VMs is being deleted it will have it's NIC detached
+		transient := vmNICTransientStates
+		transient.Append(vmNICUpdateReadyStates)
+		finalStrs := vrNICAddInstancesStates.ToStrings()
+
+		stateConf := NewVMUpdateStateConf(timeout,
+			transient.ToStrings(),
+			finalStrs,
+		)
+
+		_, errs := waitForVMsStates(ctx, controller, vrInfos.VMs.ID, stateConf)
 		if len(errs) > 0 {
 			var fullErr string
 			for _, err := range errs {
 				fullErr += fmt.Sprintf("\nVM error: %s\n", err.Error())
 			}
 			return fmt.Errorf(
-				"Virtual router waiting for virtual machines to be in state %s: %s", strings.Join(vrNICAddInstancesStates, " "), fullErr)
+				"Virtual router waiting for virtual machines to be in state %s: %s", strings.Join(finalStrs, ","), fullErr)
 		}
 	}
 

--- a/opennebula/helpers_vr.go
+++ b/opennebula/helpers_vr.go
@@ -14,7 +14,7 @@ import (
 	"github.com/OpenNebula/one/src/oca/go/src/goca/schemas/vm"
 )
 
-var vrNICAddInstancesStates = VMStates{
+var vrNICDeleteInstancesStates = VMStates{
 	States: []vm.State{vm.Poweroff, vm.Done},
 	LCMs:   []vm.LCMState{vm.Running},
 }
@@ -170,7 +170,8 @@ func vrNICDetach(ctx context.Context, timeout time.Duration, controller *goca.Co
 		// If one of the VMs is being deleted it will have it's NIC detached
 		transient := vmNICTransientStates
 		transient.Append(vmNICUpdateReadyStates)
-		finalStrs := vrNICAddInstancesStates.ToStrings()
+		transient.Append(vmDeleteTransientStates)
+		finalStrs := vrNICDeleteInstancesStates.ToStrings()
 
 		stateConf := NewVMUpdateStateConf(timeout,
 			transient.ToStrings(),

--- a/opennebula/resource_opennebula_virtual_machine.go
+++ b/opennebula/resource_opennebula_virtual_machine.go
@@ -1966,6 +1966,15 @@ func resourceOpennebulaVirtualMachineDelete(ctx context.Context, d *schema.Resou
 		err = vmc.Terminate()
 	}
 
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Failed to terminate",
+			Detail:   fmt.Sprintf("virtual machine (ID: %s): %s", d.Id(), err),
+		})
+		return diags
+	}
+
 	// wait for the VM to be powered off
 	// RUNNING state is added to transient one in case of slow cloud
 	transientStrs := NewVMLCMState(vm.Running).

--- a/opennebula/resource_opennebula_virtual_network.go
+++ b/opennebula/resource_opennebula_virtual_network.go
@@ -493,10 +493,9 @@ func resourceOpennebulaVirtualNetworkCreate(ctx context.Context, d *schema.Resou
 		vnc = controller.VirtualNetwork(vnetID)
 
 		// virtual network states were introduce with OpenNebula 6.4 release
-		oneVersion, err := version.NewVersion(config.OneVersion)
-		requiredVersion, err := version.NewVersion("6.4.0")
+		requiredVersion, _ := version.NewVersion("6.4.0")
 
-		if oneVersion.GreaterThanOrEqual(requiredVersion) {
+		if config.OneVersion.GreaterThanOrEqual(requiredVersion) {
 			timeout := d.Timeout(schema.TimeoutCreate)
 			_, err = waitForVNetworkState(ctx, vnc, timeout, "READY")
 			if err != nil {

--- a/opennebula/resource_opennebula_virtual_router_instance.go
+++ b/opennebula/resource_opennebula_virtual_router_instance.go
@@ -413,6 +413,7 @@ func resourceOpennebulaVirtualRouterInstanceUpdate(ctx context.Context, d *schem
 			Severity: diag.Error,
 			Summary:  "Failed to update",
 		})
+		return diags
 	}
 
 	return resourceOpennebulaVirtualRouterInstanceRead(ctx, d, meta)


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

Rework state management for virtual machines and virtual router instances (they are custom VMs).
The goal is to better control the VM states to avoid failures: action being triggered against the wrong VM state, slow cloud etc.

- Rework waitForVMState method: embed less details to be more configurable, return state string by default
- add transient states, so the provider expect them and should fails less often
- add current/final states to transient states to fix the error reported in #132 in case of slow cloud (the VM was in RUNNING state more than 10secs before changing it's state, but the code was waiting for the VM to be in a transitory state and didn't expect the RUNNING state)
- reduce some timers, this should be slightly visibile on the CI running times below
- add some missing state control points (during the test I saw some errors appears due to "race conditions").
- use less state strings, it's less maintainable and may introduce errors in the future via some typos

### References

Close #132 

### New or Affected Resource(s)

<!--- Please list the new or affected resources and data sources. --->

- opennebula_virtual_machine
- opennebula_virtual_router_instance

### Checklist

<!--- Please check you didn't forgot a step to help us merging this PR. --->

- [ ] I have created an issue and I have mentioned it in `References`
- [ ] My code follows the style guidelines of this project (use `go fmt`)
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the unit tests and they pass succesfuly
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation (if needed)
- [ ] I have updated the changelog file
