### PR TITLE
B-294: Only adding volatile_format to state if no image_id is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ BUG FIXES:
 * provider: Fail on bad credentials (#288)
 * data/opennebula_template: Fix error when `cpu`, `vcpu` or `memory` undefined (#284)
 * resources/opennebula_virtual_machine: fix missing NIC generation (#289)
+* resources/opennebula_virtual_machine: only adding volatile_format to state if no image_id is set (#294)
 * resources/opennebula_virtual_machine: fix VM state management failures (#132)
 
 ## 0.5.0 (June 7th, 2022)

--- a/opennebula/resource_opennebula_virtual_machine.go
+++ b/opennebula/resource_opennebula_virtual_machine.go
@@ -629,7 +629,11 @@ func flattenVMDiskComputed(diskConfig map[string]interface{}, disk shared.Disk) 
 	if len(diskConfig["driver"].(string)) > 0 {
 		diskMap["driver"] = diskMap["computed_driver"]
 	}
-	if len(diskConfig["volatile_format"].(string)) > 0 {
+
+	// This can only be set, if image_id is not defined, otherwise it may conflict
+	// with older terraform state.
+	// It sets volatile_format even if this is not allowed to be set if there is an image_id set.
+	if len(diskConfig["volatile_format"].(string)) > 0 && diskConfig["image_id"].(int) == -1 {
 		diskMap["volatile_format"] = diskMap["computed_volatile_format"]
 	}
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

<!--- Please leave a helpful description of the PR here. --->

This PR introduces an additional check that we only populate the `volatile_format` field, if there is no conflicting field set.
If there is a conflicting field set e.g. `image_id`, this field is not allowed to be set, according to documentation. 
This resolves a bug where the unneeded state change introduces a deattach and reattach while upgrading. 

Note: I did not update any unit tests, because they does not exist for the modified part. I also did not add any documentation, because this is a bug-fix.

### References

#294

### New or Affected Resource(s)

<!--- Please list the new or affected resources and data sources. --->

- opennebula_virtual_machine

### Checklist

<!--- Please check you didn't forgot a step to help us merging this PR. --->

- [x] I have created an issue and I have mentioned it in `References`
- [x] My code follows the style guidelines of this project (use `go fmt`)
- [x] My changes generate no new warnings or errors
- [ ] I have updated the unit tests and they pass succesfuly
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have updated the documentation (if needed)
- [x] I have updated the changelog file
