### PR TITLE
WIP: Fix missing line break in VM context

### DIFF
--- a/opennebula/resource_opennebula_virtual_machine.go
+++ b/opennebula/resource_opennebula_virtual_machine.go
@@ -1379,7 +1379,7 @@ func resourceOpennebulaVirtualMachineUpdateCustom(ctx context.Context, d *schema
 						continue
 					}
 
-					contextVec.AddPair(keyUp, value)
+					contextVec.AddPair(keyUp, strings.ReplaceAll(fmt.Sprint(value), "\\n", "\n"))
 				}
 
 			} else {
@@ -2074,7 +2074,7 @@ func generateVm(d *schema.ResourceData, tplContext *dyn.Vector) (*vm.Template, e
 		for key, value := range context {
 			keyUp := strings.ToUpper(key)
 			tplContext.Del(keyUp)
-			tplContext.AddPair(keyUp, value)
+			tplContext.AddPair(keyUp, strings.ReplaceAll(fmt.Sprint(value), "\\n", "\n"))
 		}
 
 		tpl.Elements = append(tpl.Elements, tplContext)
@@ -2083,7 +2083,7 @@ func generateVm(d *schema.ResourceData, tplContext *dyn.Vector) (*vm.Template, e
 		// Add new context elements to the template
 		for key, value := range context {
 			keyUp := strings.ToUpper(key)
-			tpl.AddCtx(vmk.Context(keyUp), fmt.Sprint(value))
+			tpl.AddCtx(vmk.Context(keyUp), strings.ReplaceAll(fmt.Sprint(value), "\\n", "\n"))
 		}
 	}
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

<!--- Please leave a helpful description of the PR here. --->

Fix an issue where the line break is not rendered in the VM context attribute.

### References

#309 

### New or Affected Resource(s)

<!--- Please list the new or affected resources and data sources. --->

- opennebula_virtual_machine

### Checklist

<!--- Please check you didn't forgot a step to help us merging this PR. --->

- [x] I have created an issue and I have mentioned it in `References`
- [ ] My code follows the style guidelines of this project (use `go fmt`)
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the unit tests and they pass succesfuly
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation (if needed)
- [ ] I have updated the changelog file