### PR TITLE
B-315: delete pending vm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.5.1 (Unreleased)
+
+BUG FIXES:
+
+* resources/opennebula_virtual_machine: allow to delete a VM in PENDING state
+
 ## 0.5.1 (July 4th, 2022)
 
 ENHANCEMENTS:

--- a/opennebula/helpers_vm_state.go
+++ b/opennebula/helpers_vm_state.go
@@ -29,7 +29,7 @@ var (
 
 	// Deletion: terminate the VM
 	vmDeleteReadyStates = VMStates{
-		States: []vm.State{vm.Hold, vm.Poweroff, vm.Stopped, vm.Undeployed, vm.Suspended, vm.Done},
+		States: []vm.State{vm.Hold, vm.Poweroff, vm.Stopped, vm.Undeployed, vm.Suspended, vm.Done, vm.Pending},
 		LCMs:   []vm.LCMState{vm.Running},
 	}
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

<!--- Please leave a helpful description of the PR here. --->
This PR allow to terminate a VM in PENDING state.

### References

Close #315 

### New or Affected Resource(s)

<!--- Please list the new or affected resources and data sources. --->

- opennebula_virtual_machine
- opennebula_virtual_router_instance

### Checklist

<!--- Please check you didn't forgot a step to help us merging this PR. --->

- [x] I have created an issue and I have mentioned it in `References`
- [x] My code follows the style guidelines of this project (use `go fmt`)
- [x] My changes generate no new warnings or errors
- [x] I have updated the unit tests and they pass succesfuly
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation (if needed)
- [x] I have updated the changelog file
