### PR TITLE
B-330: inherit template elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.0.0 (Unreleased)
 
+BUG FIXES:
+
+* resource/opennebula_virtual_machine: Fix diff on template inherited attributes `sched_requirements` and `sched_ds_requirements`
+
 FEATURES:
 
 * **New Resource**: `opennebula_virtual_network_address_range` (#279)

--- a/opennebula/shared_schemas.go
+++ b/opennebula/shared_schemas.go
@@ -867,6 +867,9 @@ func flattenTemplate(d *schema.ResourceData, vmTemplate *vm.Template) error {
 
 func flattenVMUserTemplate(d *schema.ResourceData, vmTemplate *dynamic.Template) error {
 
+	// We read attributes only if they are described in the VM description
+	// to avoid a diff due to template attribute inheritence
+
 	var err error
 
 	tags := make(map[string]interface{})
@@ -885,27 +888,39 @@ func flattenVMUserTemplate(d *schema.ResourceData, vmTemplate *dynamic.Template)
 		}
 	}
 
-	schedReq, err := vmTemplate.GetStr("SCHED_REQUIREMENTS")
-	if err == nil {
-		err = d.Set("sched_requirements", schedReq)
-		if err != nil {
-			return err
+	schedReqCfg := d.Get("sched_requirements").(string)
+
+	if len(schedReqCfg) > 0 {
+		schedReq, err := vmTemplate.GetStr("SCHED_REQUIREMENTS")
+		if err == nil {
+			err = d.Set("sched_requirements", schedReq)
+			if err != nil {
+				return err
+			}
 		}
 	}
 
-	schedDSReq, err := vmTemplate.GetStr("SCHED_DS_REQUIREMENTS")
-	if err == nil {
-		err = d.Set("sched_ds_requirements", schedDSReq)
-		if err != nil {
-			return err
+	schedDSReqCfg := d.Get("sched_ds_requirements").(string)
+
+	if len(schedDSReqCfg) > 0 {
+		schedDSReq, err := vmTemplate.GetStr("SCHED_DS_REQUIREMENTS")
+		if err == nil {
+			err = d.Set("sched_ds_requirements", schedDSReq)
+			if err != nil {
+				return err
+			}
 		}
 	}
 
-	desc, err := vmTemplate.GetStr("DESCRIPTION")
-	if err == nil {
-		err = d.Set("description", desc)
-		if err != nil {
-			return err
+	descriptionCfg := d.Get("description").(string)
+
+	if len(descriptionCfg) > 0 {
+		description, err := vmTemplate.GetStr("DESCRIPTION")
+		if err == nil {
+			err = d.Set("description", description)
+			if err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

<!--- Please leave a helpful description of the PR here. --->

I finally implemented a simpler solution than proposed in #330.
I added a check to read the sched_* attributes only when set by the user (they are not computed in the schema), and then I added an acceptance test to reproduce the problem

### References

Close #330 

### New or Affected Resource(s)

<!--- Please list the new or affected resources and data sources. --->

- opennebula_virtual_machine
- opennebula_virtual_router_instance

### Checklist

<!--- Please check you didn't forgot a step to help us merging this PR. --->

- [ ] I have created an issue and I have mentioned it in `References`
- [ ] My code follows the style guidelines of this project (use `go fmt`)
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the unit tests and they pass succesfuly
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation (if needed)
- [ ] I have updated the changelog file
