### PR TITLE
F-300: add host resource and datasource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ FEATURES:
 * resources/opennebula_virtual_router: add `template_section` to manage vectors with an unique key (#359)
 * resources/opennebula_virtual_router_instance: add `template_section` to manage vectors with an unique key (#359)
 * resources/opennebula_virtual_router_instance_template: add `template_section` to manage vectors with an unique key (#359)
+* **New Resource**: `opennebula_host` (#300)
+* **New Data source**: `opennebula_host` (#300)
 
 DEPRECATION:
 

--- a/opennebula/data_opennebula_host.go
+++ b/opennebula/data_opennebula_host.go
@@ -1,0 +1,99 @@
+package opennebula
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	hostSc "github.com/OpenNebula/one/src/oca/go/src/goca/schemas/host"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataOpennebulaHost() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: datasourceOpennebulaHostRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Name of the host",
+			},
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func hostFilter(d *schema.ResourceData, meta interface{}) (*hostSc.Host, error) {
+
+	config := meta.(*Configuration)
+	controller := config.Controller
+
+	hosts, err := controller.Hosts().Info()
+	if err != nil {
+		return nil, err
+	}
+
+	// filter hosts with user defined criterias
+	name, nameOk := d.GetOk("name")
+	tagsInterface, tagsOk := d.GetOk("tags")
+	tags := tagsInterface.(map[string]interface{})
+
+	match := make([]*hostSc.Host, 0, 1)
+	for i, host := range hosts.Hosts {
+
+		if nameOk && host.Name != name {
+			continue
+		}
+
+		if tagsOk && !matchTags(host.Template.Template, tags) {
+			continue
+		}
+
+		match = append(match, &hosts.Hosts[i])
+	}
+
+	// check filtering results
+	if len(match) == 0 {
+		return nil, fmt.Errorf("no host match the constraints")
+	} else if len(match) > 1 {
+		return nil, fmt.Errorf("several hosts match the constraints")
+	}
+
+	return match[0], nil
+}
+
+func datasourceOpennebulaHostRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+
+	var diags diag.Diagnostics
+
+	host, err := hostFilter(d, meta)
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "hosts filtering failed",
+			Detail:   err.Error(),
+		})
+		return diags
+	}
+
+	tplPairs := pairsToMap(host.Template.Template)
+
+	d.SetId(strconv.FormatInt(int64(host.ID), 10))
+	d.Set("name", host.Name)
+
+	if len(tplPairs) > 0 {
+		err := d.Set("tags", tplPairs)
+		if err != nil {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  "setting attribute failed",
+				Detail:   fmt.Sprintf("Host (ID: %d): %s", host.ID, err),
+			})
+			return diags
+		}
+	}
+
+	return nil
+}

--- a/opennebula/provider.go
+++ b/opennebula/provider.go
@@ -75,6 +75,7 @@ func Provider() *schema.Provider {
 			"opennebula_virtual_data_center":   dataOpennebulaVirtualDataCenter(),
 			"opennebula_virtual_network":       dataOpennebulaVirtualNetwork(),
 			"opennebula_virtual_machine_group": dataOpennebulaVMGroup(),
+			"opennebula_host":                  dataOpennebulaHost(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -97,6 +98,7 @@ func Provider() *schema.Provider {
 			"opennebula_virtual_router_nic":               resourceOpennebulaVirtualRouterNIC(),
 			"opennebula_virtual_network_address_range":    resourceOpennebulaVirtualNetworkAddressRange(),
 			"opennebula_cluster":                          resourceOpennebulaCluster(),
+			"opennebula_host":                             resourceOpennebulaHost(),
 		},
 
 		ConfigureContextFunc: providerConfigure,

--- a/opennebula/resource_opennebula_host.go
+++ b/opennebula/resource_opennebula_host.go
@@ -1,0 +1,565 @@
+package opennebula
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/OpenNebula/one/src/oca/go/src/goca"
+	dyn "github.com/OpenNebula/one/src/oca/go/src/goca/dynamic"
+	"github.com/OpenNebula/one/src/oca/go/src/goca/parameters"
+	"github.com/OpenNebula/one/src/oca/go/src/goca/schemas/host"
+	hostk "github.com/OpenNebula/one/src/oca/go/src/goca/schemas/host/keys"
+)
+
+var hostTypes = []string{"KVM", "QEMU", "LXD", "LXC", "FIRECRACKER", "VCENTER", "CUSTOM"}
+var defaultHostMinTimeout = 20
+var defaultHostTimeout = time.Duration(defaultHostMinTimeout) * time.Minute
+
+func resourceOpennebulaHost() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceOpennebulaHostCreate,
+		ReadContext:   resourceOpennebulaHostRead,
+		UpdateContext: resourceOpennebulaHostUpdate,
+		DeleteContext: resourceOpennebulaHostDelete,
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(defaultHostTimeout),
+			Delete: schema.DefaultTimeout(defaultHostTimeout),
+		},
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Name of the Host",
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Type of the new host: kvm, qemu, lxd, lxc, firecracker, custom",
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					value := strings.ToUpper(v.(string))
+
+					if inArray(value, hostTypes) < 0 {
+						errors = append(errors, fmt.Errorf("host \"type\" must be one of: %s", strings.Join(hostTypes, ",")))
+					}
+
+					return
+				},
+			},
+			"custom": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"virtualization": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Virtualization driver",
+						},
+						"information": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Information driver",
+						},
+					},
+				},
+			},
+			"overcommit": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"cpu": {
+							Type:        schema.TypeInt,
+							Required:    true,
+							Description: "Maximum allocatable CPU capacity in number of cores multiplied by 100",
+						},
+						"memory": {
+							Type:        schema.TypeInt,
+							Required:    true,
+							Description: "Maximum allocatable memory capacity in KB",
+						},
+					},
+				},
+			},
+			"cluster_id": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     -1,
+				Description: "ID of the cluster",
+			},
+			"tags":         tagsSchema(),
+			"default_tags": defaultTagsSchemaComputed(),
+			"tags_all":     tagsSchemaComputed(),
+		},
+	}
+}
+
+func getHostController(d *schema.ResourceData, meta interface{}) (*goca.HostController, error) {
+	config := meta.(*Configuration)
+	controller := config.Controller
+
+	uid, err := strconv.ParseUint(d.Id(), 10, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	return controller.Host(int(uid)), nil
+}
+
+func resourceOpennebulaHostCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Configuration)
+	controller := config.Controller
+
+	var diags diag.Diagnostics
+
+	name := d.Get("name").(string)
+	hostType := strings.ToUpper(d.Get("type").(string))
+
+	var vmMad, imMad string
+
+	switch hostType {
+	case "KVM", "QEMU", "LXD", "LXC", "FIRECRACKER":
+		imMad = hostType
+		vmMad = hostType
+
+	case "VCENTER":
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "The VCENTER type is not managed.",
+		})
+		return diags
+	case "CUSTOM":
+
+		madsList := d.Get("custom").(*schema.Set).List()
+
+		for _, madsIf := range madsList {
+			madsMap := madsIf.(map[string]interface{})
+			imMadIf, ok := madsMap["information"]
+			if !ok {
+				diags = append(diags, diag.Diagnostic{
+					Severity: diag.Error,
+					Summary:  "No information field found in the custom section",
+				})
+				return diags
+			}
+			imMad = imMadIf.(string)
+			vmMadIf, ok := madsMap["virtualization"]
+			if !ok {
+				diags = append(diags, diag.Diagnostic{
+					Severity: diag.Error,
+					Summary:  "No virtualization field found in the custom section",
+				})
+				return diags
+			}
+			vmMad = vmMadIf.(string)
+		}
+
+	}
+
+	clusterID := d.Get("cluster_id").(int)
+
+	hostID, err := controller.Hosts().Create(name, imMad, vmMad, clusterID)
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Failed to create the host",
+			Detail:   err.Error(),
+		})
+		return diags
+	}
+	d.SetId(fmt.Sprintf("%v", hostID))
+
+	log.Printf("[INFO] Host created")
+
+	hc := controller.Host(hostID)
+
+	timeout := d.Timeout(schema.TimeoutCreate)
+	_, err = waitForHostStates(ctx, hc, timeout, []string{"INIT", "MONITORING_INIT", "MONITORING_MONITORED"}, []string{"MONITORED"})
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Failed to wait host to be in MONITORED state",
+			Detail:   fmt.Sprintf("host (ID: %s): %s", d.Id(), err),
+		})
+		return diags
+	}
+
+	hostTpl, err := generateHostTemplate(d, meta, hc)
+
+	hostTplStr := hostTpl.String()
+	log.Printf("[INFO] Host template: %s", hostTplStr)
+
+	err = hc.Update(hostTplStr, parameters.Replace)
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Failed to retrieve information",
+			Detail:   fmt.Sprintf("host (ID: %s): %s", d.Id(), err),
+		})
+		return diags
+	}
+
+	return resourceOpennebulaHostRead(ctx, d, meta)
+}
+
+func generateHostTemplate(d *schema.ResourceData, meta interface{}, hc *goca.HostController) (*dyn.Template, error) {
+
+	config := meta.(*Configuration)
+	tpl := dyn.NewTemplate()
+
+	err := generateHostOvercommit(d, meta, hc, tpl)
+	if err != nil {
+		return nil, err
+	}
+
+	tagsInterface := d.Get("tags").(map[string]interface{})
+	for k, v := range tagsInterface {
+		tpl.AddPair(strings.ToUpper(k), v)
+	}
+
+	// add default tags if they aren't overriden
+	if len(config.defaultTags) > 0 {
+		for k, v := range config.defaultTags {
+			key := strings.ToUpper(k)
+			p, _ := tpl.GetPair(key)
+			if p != nil {
+				continue
+			}
+			tpl.AddPair(key, v)
+		}
+	}
+
+	return tpl, nil
+}
+
+func generateHostOvercommit(d *schema.ResourceData, meta interface{}, hc *goca.HostController, tpl *dyn.Template) error {
+
+	overcommit, ok := d.GetOk("overcommit")
+	if ok {
+		overcommitList := overcommit.(*schema.Set).List()
+
+		hostInfos, err := hc.Info(false)
+		if err != nil {
+			return fmt.Errorf("Failed to retrieve informations")
+		}
+
+		for _, overcommitIf := range overcommitList {
+			overcommitMap := overcommitIf.(map[string]interface{})
+			cpuIf, ok := overcommitMap["cpu"]
+			if !ok {
+				return fmt.Errorf("No cpu field found in the overcommit section")
+			}
+			memoryIf, ok := overcommitMap["memory"]
+			if !ok {
+				return fmt.Errorf("No memory field found in the overcommit section")
+			}
+
+			reservedCPU := cpuIf.(int) - hostInfos.Share.TotalCPU
+			reservedMem := memoryIf.(int) - hostInfos.Share.TotalMem
+
+			tpl.AddPair("RESERVED_CPU", reservedCPU)
+			tpl.AddPair("RESERVED_MEMORY", reservedMem)
+		}
+	}
+
+	return nil
+}
+
+func resourceOpennebulaHostRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+
+	var diags diag.Diagnostics
+	config := meta.(*Configuration)
+
+	hc, err := getHostController(d, meta)
+	if err != nil {
+		if NoExists(err) {
+			log.Printf("[WARN] Removing host %s from state because it no longer exists in", d.Get("name"))
+			d.SetId("")
+			return nil
+		}
+
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Failed to get the host controller",
+			Detail:   err.Error(),
+		})
+		return diags
+
+	}
+
+	hostInfos, err := hc.Info(false)
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Failed to retrieve informations",
+			Detail:   fmt.Sprintf("host (ID: %s): %s", d.Id(), err),
+		})
+		return diags
+	}
+
+	d.SetId(fmt.Sprintf("%v", hostInfos.ID))
+	d.Set("name", hostInfos.Name)
+
+	tags := make(map[string]interface{})
+	tagsAll := make(map[string]interface{})
+
+	custom := d.Get("custom").(*schema.Set).List()
+	if len(custom) > 0 {
+		fmt.Printf("[INFO] custom configured, read...")
+
+		d.Set("custom", []map[string]interface{}{
+			{
+				"information":    hostInfos.IMMAD,
+				"virtualization": hostInfos.VMMAD,
+			},
+		})
+	}
+
+	overcommit := d.Get("overcommit").(*schema.Set).List()
+	if len(overcommit) > 0 {
+		overcommitMap := make(map[string]interface{})
+
+		reservedCPU, err := hostInfos.Template.GetI(hostk.ReservedCPU)
+		if err == nil {
+			overcommitMap["cpu"] = reservedCPU + hostInfos.Share.TotalCPU
+		}
+
+		reservedMem, err := hostInfos.Template.GetInt("RESERVED_MEMORY")
+		if err == nil {
+			overcommitMap["memory"] = reservedMem + hostInfos.Share.TotalMem
+		}
+
+		d.Set("overcommit", []map[string]interface{}{overcommitMap})
+	}
+
+	// Get default tags
+	oldDefault := d.Get("default_tags").(map[string]interface{})
+	for k, _ := range oldDefault {
+		tagValue, err := hostInfos.Template.GetStr(strings.ToUpper(k))
+		if err != nil {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  "Failed to get default tag",
+				Detail:   fmt.Sprintf("host (ID: %s): %s", d.Id(), err),
+			})
+			return diags
+		}
+		tagsAll[k] = tagValue
+	}
+	d.Set("default_tags", config.defaultTags)
+
+	// Get only tags described in the configuration
+	if tagsInterface, ok := d.GetOk("tags"); ok {
+		for k, _ := range tagsInterface.(map[string]interface{}) {
+			tagValue, err := hostInfos.Template.GetStr(strings.ToUpper(k))
+			if err != nil {
+				diags = append(diags, diag.Diagnostic{
+					Severity: diag.Error,
+					Summary:  "Failed to get tag from the host template",
+					Detail:   fmt.Sprintf("host (ID: %s): %s", d.Id(), err),
+				})
+				return diags
+
+			}
+			tags[k] = tagValue
+			tagsAll[k] = tagValue
+		}
+
+		err := d.Set("tags", tags)
+		if err != nil {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  "Failed to set attribute",
+				Detail:   fmt.Sprintf("host (ID: %s): %s", d.Id(), err),
+			})
+			return diags
+		}
+	}
+	d.Set("tags_all", tagsAll)
+
+	return nil
+}
+
+func resourceOpennebulaHostUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+
+	var diags diag.Diagnostics
+
+	hc, err := getHostController(d, meta)
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Failed to get the host controller",
+			Detail:   err.Error(),
+		})
+		return diags
+	}
+
+	hostInfos, err := hc.Info(false)
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Failed to retrieve informations",
+			Detail:   fmt.Sprintf("host (ID: %s): %s", d.Id(), err),
+		})
+		return diags
+	}
+
+	if d.HasChange("name") {
+		err := hc.Rename(d.Get("name").(string))
+		if err != nil {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  "Failed to rename",
+				Detail:   fmt.Sprintf("host (ID: %s): %s", d.Id(), err),
+			})
+			return diags
+		}
+		log.Printf("[INFO] Successfully updated name for host %s\n", hostInfos.Name)
+	}
+
+	update := false
+	newTpl := hostInfos.Template
+
+	if d.HasChange("overcommit") {
+		newTpl.Del("RESERVED_CPU")
+		newTpl.Del("RESERVED_MEMORY")
+		err := generateHostOvercommit(d, meta, hc, &newTpl.Template)
+		if err != nil {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  "Failed to compute host overcommit",
+				Detail:   fmt.Sprintf("host (ID: %s): %s", d.Id(), err),
+			})
+			return diags
+		}
+		update = true
+	}
+
+	if d.HasChange("tags") {
+
+		oldTagsIf, newTagsIf := d.GetChange("tags")
+		oldTags := oldTagsIf.(map[string]interface{})
+		newTags := newTagsIf.(map[string]interface{})
+
+		// delete tags
+		for k, _ := range oldTags {
+			_, ok := newTags[k]
+			if ok {
+				continue
+			}
+			newTpl.Del(strings.ToUpper(k))
+		}
+
+		// add/update tags
+		for k, v := range newTags {
+			newTpl.Del(strings.ToUpper(k))
+			newTpl.AddPair(strings.ToUpper(k), v)
+		}
+
+		update = true
+	}
+
+	if update {
+		err = hc.Update(newTpl.String(), parameters.Replace)
+		if err != nil {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  "Failed to update content",
+				Detail:   fmt.Sprintf("host (ID: %s): %s", d.Id(), err),
+			})
+			return diags
+		}
+	}
+
+	return resourceOpennebulaHostRead(ctx, d, meta)
+}
+
+func resourceOpennebulaHostDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+
+	var diags diag.Diagnostics
+
+	hc, err := getHostController(d, meta)
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Failed to get the host controller",
+			Detail:   err.Error(),
+		})
+		return diags
+	}
+
+	err = hc.Delete()
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Failed to delete the host",
+			Detail:   fmt.Sprintf("host (ID: %s): %s", d.Id(), err),
+		})
+		return diags
+	}
+
+	timeout := d.Timeout(schema.TimeoutDelete)
+	_, err = waitForHostStates(ctx, hc, timeout, []string{"INIT", "MONITORING_INIT", "MONITORING_MONITORED", "MONITORED"}, []string{"notfound"})
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Failed to wait host to be in notfound state",
+			Detail:   fmt.Sprintf("host (ID: %s): %s", d.Id(), err),
+		})
+		return diags
+	}
+	return nil
+}
+
+// waitForHostStates wait for a an host to reach some expected states
+func waitForHostStates(ctx context.Context, hc *goca.HostController, timeout time.Duration, pending, target []string) (interface{}, error) {
+
+	stateChangeConf := resource.StateChangeConf{
+		Pending:    pending,
+		Target:     target,
+		Timeout:    timeout,
+		Delay:      10 * time.Second,
+		MinTimeout: 3 * time.Second,
+		Refresh: func() (interface{}, string, error) {
+
+			log.Println("Refreshing host state...")
+
+			hostInfos, err := hc.Info(false)
+			if err != nil {
+				if NoExists(err) {
+					return hostInfos, "notfound", nil
+				}
+				return hostInfos, "", err
+			}
+			state, err := hostInfos.State()
+			if err != nil {
+				return hostInfos, "", err
+			}
+
+			log.Printf("Host (ID:%d, name:%s) is currently in state %s", hostInfos.ID, hostInfos.Name, state.String())
+
+			// In case we are in some failure state, we try to retrieve more error informations from the host template
+			if state == host.Error {
+				hostErr, _ := hostInfos.Template.Get("ERROR")
+				return hostInfos, state.String(), fmt.Errorf("Host (ID:%d) entered fail state, error: %s", hostInfos.ID, hostErr)
+			}
+
+			return hostInfos, state.String(), nil
+		},
+	}
+
+	return stateChangeConf.WaitForStateContext(ctx)
+
+}

--- a/opennebula/resource_opennebula_host_test.go
+++ b/opennebula/resource_opennebula_host_test.go
@@ -1,0 +1,114 @@
+package opennebula
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccHost(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckHostDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHostConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("opennebula_host.test1", "name", "test-custom"),
+					resource.TestCheckResourceAttr("opennebula_host.test1", "type", "custom"),
+					resource.TestCheckTypeSetElemNestedAttrs("opennebula_host.test1", "custom.*", map[string]string{
+						"virtualization": "dummy",
+						"information":    "dummy",
+					}),
+					resource.TestCheckResourceAttr("opennebula_host.test1", "cluster_id", "0"),
+					resource.TestCheckResourceAttr("opennebula_host.test1", "tags.%", "2"),
+					resource.TestCheckResourceAttr("opennebula_host.test1", "tags.environment", "example"),
+					resource.TestCheckResourceAttr("opennebula_host.test1", "tags.test", "test"),
+				),
+			},
+			{
+				Config: testAccHostConfigAddOvercommit,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("opennebula_host.test1", "name", "test-custom"),
+					resource.TestCheckResourceAttr("opennebula_host.test1", "type", "custom"),
+					resource.TestCheckResourceAttr("opennebula_host.test1", "cluster_id", "0"),
+					resource.TestCheckTypeSetElemNestedAttrs("opennebula_host.test1", "custom.*", map[string]string{
+						"virtualization": "dummy",
+						"information":    "dummy",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs("opennebula_host.test1", "overcommit.*", map[string]string{
+						"cpu":    "3200",
+						"memory": "1048576",
+					}),
+					resource.TestCheckResourceAttr("opennebula_host.test1", "tags.%", "2"),
+					resource.TestCheckResourceAttr("opennebula_host.test1", "tags.environment", "example-updated"),
+					resource.TestCheckResourceAttr("opennebula_host.test1", "tags.customer", "test"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckHostDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Configuration)
+	controller := config.Controller
+
+	for _, rs := range s.RootModule().Resources {
+		hostID, _ := strconv.ParseUint(rs.Primary.ID, 10, 0)
+		ic := controller.Host(int(hostID))
+		// Get Host Info
+		// TODO: fix it after 5.10 release
+		// Force the "decrypt" bool to false to keep ONE 5.8 behavior
+		host, _ := ic.Info(false)
+		if host != nil {
+			return fmt.Errorf("Expected host %s to have been destroyed", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+var testAccHostConfig = `
+resource "opennebula_host" "test1" {
+	name       = "test-custom"
+	type       = "custom"
+	cluster_id = 0
+
+	custom {
+		virtualization = "dummy"
+		information = "dummy"
+	}
+  
+	tags = {
+	  test = "test"
+	  environment = "example"
+	}
+  }
+`
+
+var testAccHostConfigAddOvercommit = `
+resource "opennebula_host" "test1" {
+	name       = "test-custom"
+	type       = "custom"
+	cluster_id = 0
+
+	custom {
+		virtualization = "dummy"
+		information = "dummy"
+	}
+  
+	overcommit {
+	  cpu = 3200        # 32 cores
+	  memory = 1048576  # 1 Gb
+	}
+  
+	tags = {
+	  environment = "example-updated"
+	  customer = "test"
+	}
+  }
+`

--- a/website/docs/d/host.html.markdown
+++ b/website/docs/d/host.html.markdown
@@ -1,0 +1,30 @@
+---
+layout: "opennebula"
+page_title: "OpenNebula: opennebula_host"
+sidebar_current: "docs-opennebula-datasource-host"
+description: |-
+  Get the host information for a given name.
+---
+
+# opennebula_host
+
+Use this data source to retrieve the host information for a given name.
+
+## Example Usage
+
+```hcl
+data "opennebula_host" "example" {
+  name = "My_Host"
+}
+```
+
+## Argument Reference
+
+* `name` - (Optional) The OpenNebula host to retrieve information for.
+* `tags` - (Optional) Tags associated to the host.
+
+## Attribute Reference
+
+* `id` - ID of the host.
+* `name` - Name of the host.
+* `tags` - Tags of the host (Key = Value).

--- a/website/docs/r/host.html.markdown
+++ b/website/docs/r/host.html.markdown
@@ -1,0 +1,95 @@
+---
+layout: "opennebula"
+page_title: "OpenNebula: opennebula_host"
+sidebar_current: "docs-opennebula-resource-host"
+description: |-
+  Provides an OpenNebula host resource.
+---
+
+# opennebula_host
+
+Provides an OpenNebula host resource.
+
+This resource allows you to manage hosts on your OpenNebula clusters. When applied,
+a new host is created. When destroyed, this host is removed.
+
+## Example Usage
+
+Create a KVM host with overcommit:
+
+```hcl
+resource "opennebula_host" "example" {
+  name       = "test-kvm"
+  type       = "kvm"
+  cluster_id = 0
+
+  overcommit {
+    cpu = 3200        # 32 cores
+    memory = 1048576  # 1 Gb
+  }
+
+  tags = {
+    environment = "example"
+  }
+}
+```
+
+Create a custom host:
+
+```hcl
+resource "opennebula_host" "example" {
+  name       = "test-kvm"
+  type       = "custom"
+  cluster_id = 0
+
+  custom = {
+    virtualization = "custom"
+    information    = "custom"
+  }
+
+  tags = {
+    environment = "example"
+  }
+}
+```
+
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the host.
+* `type` - (Required) Type of the new host: kvm, qemu, lxd, lxc, firecracker, custom. For now vcenter type is not managed by the provider.
+* `cluster_id` - (Optional) ID of the cluster the host is part of.
+* `custom` - (Optional) If `type="custom"` this section should be defined, see [Custom](#custom) section for details.
+* `overcommit` - (Optional) This section allow to increase the allocatable capacity of the host. See [Overcommit](#overcommit)
+* `tags` - (Optional) Host tags (Key = value)
+* `timeout` - (Deprecated) Timeout (in Minutes) for Host availability. Defaults to 10 minutes.
+
+### Custom
+
+When the attribute `type` is set to `custom` this section allow to set the details with these arguments:
+
+* `virtualization` - (Optional) name of the virtualization driver (named `VM_MAD` in OpenNebula)
+* `information` - (Optional) name of the information driver (named `IM_MAD` in opennebula)
+
+### Overcommit
+
+* `cpu` - (Optional) Maximum allocatable CPU capacity  in number of cores multiplied by 100.
+* `memory` - (Optional) Maximum allocatable memory in KB.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `id` - ID of the host.
+* `tags_all` - Result of the applied `default_tags` and then resource `tags`.
+* `default_tags` - Default tags defined in the provider configuration.
+
+## Import
+
+`opennebula_host` can be imported using its ID:
+
+```shell
+terraform import opennebula_host.example 123
+```


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

<!--- Please leave a helpful description of the PR here. --->

Adds `opennebula_host` resources and data sources.
However, the ressource doesn't manage the `vcenter` hosts types (import vmware resources require a script: https://docs.opennebula.io/6.4/vmware_cluster_deployment/vmware_cluster_deployment/vcenter_node_installation.html#importing-vcenter-clusters).

### References

Close #300

### New or Affected Resource(s)

<!--- Please list the new or affected resources and data sources. --->

- opennebula_host

### Checklist

<!--- Please check you didn't forgot a step to help us merging this PR. --->

- [ ] I have created an issue and I have mentioned it in `References`
- [ ] My code follows the style guidelines of this project (use `go fmt`)
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the unit tests and they pass succesfuly
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation (if needed)
- [ ] I have updated the changelog file
