### PR TITLE
B #331: fixing template filtering function, removing has_xxx parameters

### DIFF
--- a/opennebula/data_opennebula_template.go
+++ b/opennebula/data_opennebula_template.go
@@ -27,7 +27,6 @@ func dataOpennebulaTemplate() *schema.Resource {
 				s.ValidateFunc = func(v interface{}, k string) (ws []string, errs []error) {
 					value := v.(float64)
 
-
 					if value == 0 {
 						errs = append(errs, errors.New("cpu should be strictly greater than 0"))
 					}

--- a/website/docs/d/template.html.markdown
+++ b/website/docs/d/template.html.markdown
@@ -21,11 +21,8 @@ data "opennebula_template" "example" {
 ## Argument Reference
 
 * `name` - (Optional) The OpenNebula template to retrieve information for.
-* `has_cpu` - (Optional) Indicate if a CPU value has been defined.
 * `cpu` - (Optional) Amount of CPU shares assigned to the VM.
-* `has_cvpu` - (Optional) Indicate if a VCPU value has been defined.
 * `vpcu` - (Optional) Number of CPU cores presented to the VM.
-* `has_memory` - (Optional) Indicate if a memory value has been defined.
 * `memory` - (Optional) Amount of RAM assigned to the VM in MB.
 * `context` - (Deprecated) Array of free form key=value pairs, rendered and added to the CONTEXT variables for the VM. Recommended to include: `NETWORK = "YES"` and `SET_HOSTNAME = "$NAME"`.
 * `graphics` - (Deprecated) Graphics parameters.


### PR DESCRIPTION
Signed-off-by: Neal Hansen <nhansen@opennebula.io>

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

### Description

Changes the template list function call to grab from all templates instead of just owned ones (group and other permissions in OpenNebula allow use when not owned)
Changes the template filter to filter based on present parameters, should not need the `has_XXX` parameter any longer.  Instead, it uses the second returned value from `GetOk` which will indicate whether the value is present in the configuration or not. The value cannot be set to 0 in the config file, due to the schema ValidateFunc in each resource parameter throwing an error, so there should not be a case where the value is 0 and the Ok is true.

### References

#331 
#287  (This PR essentially undoes these changes)

### Checklist

<!--- Please check you didn't forgot a step to help us merging this PR. --->

- [x] I have mentioned the issue in `References`
- [x] My code follows the style guidelines of this project (use `go fmt`)
- [x] My changes generate no new warnings or errors
- [ ] I have updated the unit tests and they pass successfuly
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation (if needed)
- [ ] I have updated the changelog file
