### PR TITLE
F-359: manage template vectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 FEATURES:
 
 * **New Resource**: `opennebula_cluster` (#227)
+* resources/opennebula_cluster: add `template_section` to manage vectors with an unique key (#359)
+* resources/opennebula_group: add `template_section` to manage vectors with an unique key (#359)
+* resources/opennebula_image: add `template_section` to manage vectors with an unique key (#359)
+* resources/opennebula_security_group: add `template_section` to manage vectors with an unique key (#359)
+* resources/opennebula_template: add `template_section` to manage vectors with an unique key (#359)
+* resources/opennebula_vm_group: add `template_section` to manage vectors with an unique key (#359)
+* resources/opennebula_user: add `template_section` to manage vectors with an unique key (#359)
+* resources/opennebula_virtual_machine: add `template_section` to manage vectors with an unique key (#359)
+* resources/opennebula_virtual_network: add `template_section` to manage vectors with an unique key (#359)
+* resources/opennebula_virtual_router: add `template_section` to manage vectors with an unique key (#359)
+* resources/opennebula_virtual_router_instance: add `template_section` to manage vectors with an unique key (#359)
+* resources/opennebula_virtual_router_instance_template: add `template_section` to manage vectors with an unique key (#359)
 
 DEPRECATION:
 

--- a/opennebula/resource_opennebula_group_test.go
+++ b/opennebula/resource_opennebula_group_test.go
@@ -45,6 +45,12 @@ func TestAccGroup(t *testing.T) {
 					resource.TestCheckResourceAttr("opennebula_group.group", "tags.%", "2"),
 					resource.TestCheckResourceAttr("opennebula_group.group", "tags.testkey1", "testvalue1"),
 					resource.TestCheckResourceAttr("opennebula_group.group", "tags.testkey2", "testvalue2"),
+					resource.TestCheckTypeSetElemNestedAttrs("opennebula_group.group", "template_section.*", map[string]string{
+						"name":              "test_vec_key",
+						"elements.%":        "2",
+						"elements.testkey1": "testvalue1",
+						"elements.testkey2": "testvalue2",
+					}),
 				),
 			},
 			{
@@ -76,6 +82,12 @@ func TestAccGroup(t *testing.T) {
 					resource.TestCheckResourceAttr("opennebula_group.group", "tags.%", "2"),
 					resource.TestCheckResourceAttr("opennebula_group.group", "tags.testkey2", "testvalue2"),
 					resource.TestCheckResourceAttr("opennebula_group.group", "tags.testkey3", "testvalue3"),
+					resource.TestCheckTypeSetElemNestedAttrs("opennebula_group.group", "template_section.*", map[string]string{
+						"name":              "test_vec_key",
+						"elements.%":        "2",
+						"elements.testkey2": "testvalue2",
+						"elements.testkey3": "testvalue3",
+					}),
 				),
 			},
 			{
@@ -92,6 +104,12 @@ func TestAccGroup(t *testing.T) {
 					resource.TestCheckResourceAttr("opennebula_group.group", "tags.%", "2"),
 					resource.TestCheckResourceAttr("opennebula_group.group", "tags.testkey2", "testvalue2"),
 					resource.TestCheckResourceAttr("opennebula_group.group", "tags.testkey3", "testvalue3"),
+					resource.TestCheckTypeSetElemNestedAttrs("opennebula_group.group", "template_section.*", map[string]string{
+						"name":              "test_vec_key",
+						"elements.%":        "2",
+						"elements.testkey2": "testvalue2",
+						"elements.testkey3": "testvalue3",
+					}),
 				),
 			},
 			{
@@ -132,6 +150,7 @@ func TestAccGroup(t *testing.T) {
 						"views":                    "cloud",
 					}),
 					resource.TestCheckResourceAttr("opennebula_group.group2", "tags.%", "0"),
+					resource.TestCheckResourceAttr("opennebula_group.group2", "template_section.#", "0"),
 				),
 			},
 		},
@@ -204,6 +223,14 @@ resource "opennebula_group" "group" {
 		testkey1 = "testvalue1"
 		testkey2 = "testvalue2"
 	}
+
+	template_section {
+		name = "test_vec_key"
+		elements = {
+			testkey1 = "testvalue1"
+			testkey2 = "testvalue2"
+		}
+	}
 }
 `
 
@@ -235,6 +262,14 @@ resource "opennebula_group" "group" {
 		testkey2 = "testvalue2"
 		testkey3 = "testvalue3"
 	}
+
+	template_section {
+		name = "test_vec_key"
+		elements = {
+			testkey2 = "testvalue2"
+			testkey3 = "testvalue3"
+		}
+	}
 }
 `
 
@@ -261,6 +296,14 @@ resource "opennebula_group" "group" {
 	tags = {
 		testkey2 = "testvalue2"
 		testkey3 = "testvalue3"
+	}
+
+	template_section {
+		name = "test_vec_key"
+		elements = {
+			testkey2 = "testvalue2"
+			testkey3 = "testvalue3"
+		}
 	}
 }
 `

--- a/opennebula/resource_opennebula_template.go
+++ b/opennebula/resource_opennebula_template.go
@@ -787,6 +787,13 @@ func resourceOpennebulaTemplateUpdateCustom(ctx context.Context, d *schema.Resou
 		update = true
 	}
 
+	if d.HasChange("template_section") {
+
+		updateTemplateSection(d, &newTpl.Template)
+
+		update = true
+	}
+
 	if d.HasChange("tags") {
 
 		oldTagsIf, newTagsIf := d.GetChange("tags")

--- a/opennebula/resource_opennebula_template_test.go
+++ b/opennebula/resource_opennebula_template_test.go
@@ -53,6 +53,12 @@ func TestAccTemplate(t *testing.T) {
 						GroupU: 1,
 						GroupM: 1,
 					}),
+					resource.TestCheckTypeSetElemNestedAttrs("opennebula_template.template", "template_section.*", map[string]string{
+						"name":              "test_vec_key",
+						"elements.%":        "2",
+						"elements.testkey1": "testvalue1",
+						"elements.testkey2": "testvalue2",
+					}),
 				),
 			},
 			{
@@ -85,6 +91,12 @@ func TestAccTemplate(t *testing.T) {
 						OwnerM: 1,
 						GroupU: 1,
 						GroupM: 1,
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs("opennebula_template.template", "template_section.*", map[string]string{
+						"name":              "test_vec_key",
+						"elements.%":        "2",
+						"elements.testkey1": "testvalue1",
+						"elements.testkey2": "testvalue2",
 					}),
 				),
 			},
@@ -122,6 +134,12 @@ func TestAccTemplate(t *testing.T) {
 						GroupU: 1,
 						OtherM: 1,
 					}),
+					resource.TestCheckTypeSetElemNestedAttrs("opennebula_template.template", "template_section.*", map[string]string{
+						"name":              "test_vec_key",
+						"elements.%":        "2",
+						"elements.testkey2": "testvalue2",
+						"elements.testkey3": "testvalue3",
+					}),
 				),
 			},
 			{
@@ -151,6 +169,11 @@ func TestAccTemplate(t *testing.T) {
 						OwnerM: 1,
 						GroupU: 1,
 						OtherM: 1,
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs("opennebula_template.template", "template_section.*", map[string]string{
+						"name":              "test_vec_key",
+						"elements.%":        "1",
+						"elements.testkey3": "testvalue3",
 					}),
 				),
 			},
@@ -258,6 +281,14 @@ resource "opennebula_template" "template" {
 	BLOG_TITLE="M|text|Blog Title"
   }
 
+  template_section {
+	name = "test_vec_key"
+	elements = {
+		testkey1 = "testvalue1"
+		testkey2 = "testvalue2"
+	}
+  }
+
 }
 `
 
@@ -297,6 +328,14 @@ resource "opennebula_template" "template" {
   }
 
   sched_requirements = "FREE_CPU > 50"
+
+  template_section {
+	name = "test_vec_key"
+	elements = {
+		testkey1 = "testvalue1"
+		testkey2 = "testvalue2"
+	}
+  }
 
 }
 `
@@ -341,6 +380,14 @@ resource "opennebula_template" "template" {
 
   sched_requirements = "CLUSTER_ID!=\"123\""
 
+  template_section {
+	name = "test_vec_key"
+	elements = {
+		testkey2 = "testvalue2"
+		testkey3 = "testvalue3"
+	}
+  }
+
 }
 `
 
@@ -373,6 +420,13 @@ resource "opennebula_template" "template" {
   tags = {
     env = "dev"
     customer = "test"
+  }
+
+  template_section {
+	name = "test_vec_key"
+	elements = {
+		testkey3 = "testvalue3"
+	}
   }
 }
 `

--- a/opennebula/resource_opennebula_virtual_machine.go
+++ b/opennebula/resource_opennebula_virtual_machine.go
@@ -1251,6 +1251,13 @@ func resourceOpennebulaVirtualMachineUpdateCustom(ctx context.Context, d *schema
 		update = true
 	}
 
+	if d.HasChange("template_section") {
+
+		updateTemplateSection(d, &tpl.Template)
+
+		update = true
+	}
+
 	if d.HasChange("tags") {
 
 		oldTagsIf, newTagsIf := d.GetChange("tags")

--- a/opennebula/resource_opennebula_virtual_machine_test.go
+++ b/opennebula/resource_opennebula_virtual_machine_test.go
@@ -56,6 +56,12 @@ func TestAccVirtualMachine(t *testing.T) {
 						GroupU: 1,
 						OtherM: 1,
 					}),
+					resource.TestCheckTypeSetElemNestedAttrs("opennebula_virtual_machine.test", "template_section.*", map[string]string{
+						"name":              "test_vec_key",
+						"elements.%":        "2",
+						"elements.testkey1": "testvalue1",
+						"elements.testkey2": "testvalue2",
+					}),
 				),
 			},
 			{
@@ -95,6 +101,12 @@ func TestAccVirtualMachine(t *testing.T) {
 						OwnerA: 0,
 						GroupU: 1,
 						GroupM: 1,
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs("opennebula_virtual_machine.test", "template_section.*", map[string]string{
+						"name":              "test_vec_key",
+						"elements.%":        "2",
+						"elements.testkey1": "testvalue_updated",
+						"elements.testkey3": "testvalue3",
 					}),
 				),
 			},
@@ -172,6 +184,7 @@ func TestAccVirtualMachine(t *testing.T) {
 						GroupU: 1,
 						GroupM: 1,
 					}),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "template_section.#", "0"),
 				),
 			},
 			{
@@ -212,6 +225,11 @@ func TestAccVirtualMachine(t *testing.T) {
 						GroupU: 1,
 						GroupM: 1,
 					}),
+					resource.TestCheckTypeSetElemNestedAttrs("opennebula_virtual_machine.test", "template_section.*", map[string]string{
+						"name":              "test_vec_key2",
+						"elements.%":        "1",
+						"elements.testkey1": "testvalue2",
+					}),
 				),
 			},
 			{
@@ -250,6 +268,13 @@ func TestAccVirtualMachine(t *testing.T) {
 						OwnerA: 0,
 						GroupU: 1,
 						GroupM: 1,
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs("opennebula_virtual_machine.test", "template_section.*", map[string]string{
+						"name":              "test_vec_key3",
+						"elements.%":        "3",
+						"elements.testkey1": "testvalue1",
+						"elements.testkey2": "testvalue2",
+						"elements.testkey3": "testvalue3",
 					}),
 				),
 			},
@@ -792,6 +817,14 @@ resource "opennebula_virtual_machine" "test" {
 
   sched_requirements = "FREE_CPU > 50"
 
+  template_section {
+	name = "test_vec_key"
+	elements = {
+		testkey1 = "testvalue1"
+		testkey2 = "testvalue2"
+	}
+  }
+
   timeout = 5
 }
 `
@@ -869,6 +902,14 @@ resource "opennebula_virtual_machine" "test" {
   sched_requirements = "FREE_CPU > 50"
 
   timeout = 4
+
+  template_section {
+	name = "test_vec_key"
+	elements = {
+		testkey1 = "testvalue_updated"
+		testkey3 = "testvalue3"
+	}
+  }
 }
 `
 
@@ -907,6 +948,14 @@ resource "opennebula_virtual_machine" "test" {
   sched_requirements = "FREE_CPU > 50"
 
   timeout = 4
+
+  template_section {
+	name = "test_vec_key"
+	elements = {
+		testkey1 = "testvalue_updated"
+		testkey3 = "testvalue3"
+	}
+  }
 }
 `
 
@@ -980,6 +1029,13 @@ resource "opennebula_virtual_machine" "test" {
   sched_requirements = "CLUSTER_ID!=\"123\""
 
   timeout = 4
+
+  template_section {
+	name = "test_vec_key2"
+	elements = {
+		testkey1 = "testvalue2"
+	}
+  }
 }
 `
 
@@ -1017,6 +1073,15 @@ resource "opennebula_virtual_machine" "test" {
   sched_requirements = "CLUSTER_ID!=\"123\""
 
   timeout = 4
+
+  template_section {
+	name = "test_vec_key3"
+	elements = {
+		testkey1 = "testvalue1"
+		testkey2 = "testvalue2"
+		testkey3 = "testvalue3"
+	}
+  }
 }
 `
 

--- a/opennebula/shared_schemas.go
+++ b/opennebula/shared_schemas.go
@@ -139,6 +139,7 @@ func commonInstanceSchema() map[string]*schema.Schema {
 		"sched_requirements":    schedReqSchema(),
 		"sched_ds_requirements": schedDSReqSchema(),
 		"description":           descriptionSchema(),
+		"template_section":      templateSectionSchema(),
 	}
 }
 
@@ -620,6 +621,11 @@ func generateVMTemplate(d *schema.ResourceData, tpl *vm.Template) error {
 		tpl.VCPU(vmvcpu.(int))
 	}
 
+	vectorsInterface := d.Get("template_section").(*schema.Set).List()
+	if len(vectorsInterface) > 0 {
+		addTemplateVectors(vectorsInterface, &tpl.Template)
+	}
+
 	tagsInterface := d.Get("tags").(map[string]interface{})
 	for k, v := range tagsInterface {
 		tpl.AddPair(strings.ToUpper(k), v)
@@ -863,6 +869,11 @@ func flattenVMUserTemplate(d *schema.ResourceData, meta interface{}, vmTemplate 
 
 	// add default_tags to tags_all
 	config := meta.(*Configuration)
+
+	err := flattenTemplateSection(d, meta, vmTemplate)
+	if err != nil {
+		return err
+	}
 
 	tagsAll := make(map[string]interface{})
 

--- a/opennebula/template_section.go
+++ b/opennebula/template_section.go
@@ -1,0 +1,139 @@
+package opennebula
+
+import (
+	"strings"
+
+	"github.com/OpenNebula/one/src/oca/go/src/goca/dynamic"
+	dyn "github.com/OpenNebula/one/src/oca/go/src/goca/dynamic"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func templateSectionSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeSet,
+		Optional:    true,
+		Description: "Add custom section to the resource",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"name": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"elements": {
+					Type:     schema.TypeMap,
+					Optional: true,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+				},
+			},
+		},
+	}
+}
+
+func addTemplateVectors(vectorsInterface []interface{}, tpl *dyn.Template) {
+
+	for _, vectorIf := range vectorsInterface {
+		vector := vectorIf.(map[string]interface{})
+		vecName := strings.ToUpper(vector["name"].(string))
+		vecElements := vector["elements"].(map[string]interface{})
+
+		vec := tpl.AddVector(strings.ToUpper(vecName))
+		for k, v := range vecElements {
+			vec.AddPair(k, v)
+		}
+	}
+}
+
+func flattenTemplateSection(d *schema.ResourceData, meta interface{}, tpl *dynamic.Template) error {
+
+	if vectorsInterface, ok := d.GetOk("template_section"); ok {
+
+		templateSection := make([]interface{}, 0)
+
+		for _, vectorIf := range vectorsInterface.(*schema.Set).List() {
+			vector := vectorIf.(map[string]interface{})
+			vecName := vector["name"].(string)
+			vecElements := vector["elements"].(map[string]interface{})
+
+			// Suppose vector key unicity
+			vectorTpl, err := tpl.GetVector(strings.ToUpper(vecName))
+			if err != nil {
+				continue
+			}
+
+			elements := make(map[string]interface{})
+			for _, pair := range vectorTpl.Pairs {
+				for k, _ := range vecElements {
+					if strings.ToUpper(k) != pair.Key() {
+						continue
+					}
+					elements[k] = pair.Value
+					break
+				}
+			}
+
+			templateSection = append(templateSection, map[string]interface{}{
+				"name":     vecName,
+				"elements": elements,
+			})
+
+		}
+
+		err := d.Set("template_section", templateSection)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func updateTemplateSection(d *schema.ResourceData, newTpl *dyn.Template) {
+
+	oldVectorsIf, newVectorsIf := d.GetChange("template_section")
+	oldVectors := oldVectorsIf.(*schema.Set).List()
+	newVectors := newVectorsIf.(*schema.Set).List()
+
+	// Here we suppose vector key unicity
+	// delete vectors
+	for _, oldVectorIf := range oldVectors {
+		oldVector := oldVectorIf.(map[string]interface{})
+		oldVectorName := oldVector["name"].(string)
+
+		if len(newVectors) == 0 {
+			newTpl.Del(strings.ToUpper(oldVectorName))
+		}
+
+		// if a new vector has the same name, keep it
+		for _, newVectorIf := range newVectors {
+			newVector := newVectorIf.(map[string]interface{})
+
+			if oldVectorName == newVector["name"].(string) {
+				continue
+			}
+			newTpl.Del(strings.ToUpper(oldVectorName))
+		}
+
+	}
+
+	// add/update vectors
+	for _, newVectorIf := range newVectors {
+		newVector := newVectorIf.(map[string]interface{})
+		newVectorName := strings.ToUpper(newVector["name"].(string))
+
+		elements := newVector["elements"].(map[string]interface{})
+
+		// it seems there is a problem, sometimes an empty map is present in newVectors list
+		// https://github.com/hashicorp/terraform-plugin-sdk/issues/588
+		if len(newVectorName) == 0 && len(elements) == 0 {
+			continue
+		}
+
+		newTpl.Del(strings.ToUpper(newVectorName))
+		newVec := newTpl.AddVector(newVectorName)
+		for k, v := range elements {
+			newVec.AddPair(k, v)
+		}
+	}
+}

--- a/website/docs/r/cluster.html.markdown
+++ b/website/docs/r/cluster.html.markdown
@@ -29,6 +29,14 @@ resource "opennebula_cluster" "example" {
   tags = {
     environment = "example"
   }
+
+  template_section {
+	  name = "test"
+	  elements = {
+		    tag1 = "value1"
+	  }
+  }
+
 }
 ```
 
@@ -41,6 +49,14 @@ The following arguments are supported:
 * `datastores` - (Optional) List of hosts user IDs part of the cluster.
 * `virtual_networks` - (Optional) List of hosts user IDs part of the cluster.
 * `tags` - (Optional) Cluster tags (Key = value)
+* `template_section` - (Optional) Allow to add a custom vector. See [Template section parameters](#template-section-parameters)
+
+### Template section parameters
+
+`template_section` supports the following arguments:
+
+* `name` - (Optional) The vector name.
+* `elements` - (Optional) Collection of custom tags.
 
 ## Attribute Reference
 

--- a/website/docs/r/group.html.markdown
+++ b/website/docs/r/group.html.markdown
@@ -52,6 +52,14 @@ resource "opennebula_group" "example" {
   tags = {
     environment = "example"
   }
+
+  template_section {
+	  name = "test"
+	  elements = {
+		    key1 = "value1"
+	  }
+  }
+
 }
 ```
 
@@ -65,6 +73,7 @@ The following arguments are supported:
 * `sunstone` - (Optional) Allow users and group admins to access specific views. See [Sunstone parameters](#sunstone-parameters) below for details
 * `opennebula` - (Optional) OpenNebula core configuration. See [Opennebula parameters](#opennebula-parameters) below for details
 * `tags` - (Optional) Group tags (Key = value)
+* `template_section` - (Optional) Allow to add a custom vector. See [Template section parameters](#template-section-parameters)
 
 ### Quotas parameters
 
@@ -109,7 +118,7 @@ The following arguments are supported:
 * `running_vms` - (Optional) Number of Virtual Machines allowed in `RUNNING` state. Defaults to `default quota`.
 * `system_disk_size` - (Optional) Maximum disk global size (in MB) allowed on a `SYSTEM` datastore. Defaults to `default quota`.
 
-#### Sunstone parameters
+### Sunstone parameters
 
 * `default_view` - (Optional) Default Sunstone view for regular users.
 * `views` - (Optional) List of available views for regular users.
@@ -121,6 +130,13 @@ The following arguments are supported:
 * `default_image_persistent` - (Optional) Control the default value for the `persistent` attribute on image creation ( clone and disk save-as).
 * `default_image_persistent_new` - (Optional) Control the default value for the `persistent` attribute on image creation ( only new images).
 * `api_list_order` - (Optional) Sets order of elements by ID in list API calls: asc or desc respectively for ascending or descending order.
+
+### Template section parameters
+
+`template_section` supports the following arguments:
+
+* `name` - (Optional) The vector name.
+* `elements` - (Optional) Collection of custom tags.
 
 ## Attribute Reference
 

--- a/website/docs/r/image.html.markdown
+++ b/website/docs/r/image.html.markdown
@@ -46,6 +46,13 @@ resource "opennebula_image" "example" {
   tags = {
     environment = "example"
   }
+
+  template_section {
+	  name = "test"
+	  elements = {
+		    key1 = "value1"
+	  }
+  }
 }
 ```
 
@@ -65,6 +72,13 @@ resource "opennebula_image" "example" {
 
   tags = {
     environment = "example"
+  }
+
+  template_section {
+	  name = "test"
+	  elements = {
+		    key1 = "value1"
+	  }
   }
 }
 ```
@@ -122,6 +136,14 @@ The following arguments are supported:
 * `group` - (Optional) Name of the group which owns the image. Defaults to the caller primary group.
 * `tags` - (Optional) Image tags (Key = value)
 * `timeout` - (Deprecated) Timeout (in Minutes) for Image availability. Defaults to 10 minutes.
+* `template_section` - (Optional) Allow to add a custom vector. See [Template section parameters](#template-section-parameters)
+
+### Template section parameters
+
+`template_section` supports the following arguments:
+
+* `name` - (Optional) The vector name.
+* `elements` - (Optional) Collection of custom tags.
 
 ## Attribute Reference
 

--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -40,6 +40,13 @@ resource "opennebula_security_group" "example" {
   tags = {
     environment = "example"
   }
+
+  template_section {
+	  name = "test"
+	  elements = {
+		    key1 = "value1"
+	  }
+  }
 }
 ```
 
@@ -54,6 +61,7 @@ The following arguments are supported:
 * `rule` - (Required) List of rules. See [Rule parameters](#rule-parameters) below for details
 * `group` - (Optional) Name of the group which owns the security group. Defaults to the caller primary group.
 * `tags` - (Optional) Security group tags (Key = Value).
+* `template_section` - (Optional) Allow to add a custom vector. See [Template section parameters](#template-section-parameters)
 
 ### Rule parameters
 
@@ -68,6 +76,13 @@ The following arguments are supported:
 * `icmp_type` - (Optional) Type of ICMP traffic to apply to when 'protocol' is `ICMP`.
 
 See <https://docs.opennebula.org/5.12/operation/network_management/security_groups.html> for more details on allowed values.
+
+### Template section parameters
+
+`template_section` supports the following arguments:
+
+* `name` - (Optional) The vector name.
+* `elements` - (Optional) Collection of custom tags.
 
 ## Attribute Reference
 

--- a/website/docs/r/template.html.markdown
+++ b/website/docs/r/template.html.markdown
@@ -69,6 +69,13 @@ resource "opennebula_template" "example" {
   tags = {
     environment = "example"
   }
+
+  template_section {
+	  name = "test"
+	  elements = {
+		    key1 = "value1"
+	  }
+  }
 }
 ```
 
@@ -97,6 +104,7 @@ The following arguments are supported:
 * `tags` - (Optional) Template tags (Key = Value).
 * `template` - (Deprecated) Text describing the OpenNebula template object, in Opennebula's XML string format.
 * `lock` - (Optional) Lock the template with a specific lock level. Supported values: `USE`, `MANAGE`, `ADMIN`, `ALL` or `UNLOCK`.
+* `template_section` - (Optional) Allow to add a custom vector. See [Template section parameters](#template-section-parameters)
 
 ### Graphics parameters
 
@@ -170,6 +178,13 @@ Minimum 1 item. Maximum 8 items.
 
 * `vmgroup_id` - (Required) ID of the VM group to use.
 * `role` - (Required) role of the VM group to use.
+
+### Template section parameters
+
+`template_section` supports the following arguments:
+
+* `name` - (Optional) The vector name.
+* `elements` - (Optional) Collection of custom tags.
 
 ## Attribute Reference
 

--- a/website/docs/r/user.html.markdown
+++ b/website/docs/r/user.html.markdown
@@ -56,6 +56,13 @@ resource "opennebula_user" "example" {
   tags = {
     environment = "example"
   }
+
+  template_section {
+	  name = "test"
+	  elements = {
+		    key1 = "value1"
+	  }
+  }
 }
 ```
 
@@ -70,6 +77,7 @@ The following arguments are supported:
 * `groups` - (Optional) List of secondary groups ID of the user.
 * `quotas` - (Optional) See [Quotas parameters](#quotas-parameters) below for details
 * `tags` - (Optional) Group tags (Key = value)
+* `template_section` - (Optional) Allow to add a custom vector. See [Template section parameters](#template-section-parameters)
 
 ### Quotas parameters
 
@@ -113,6 +121,13 @@ The following arguments are supported:
 * `running_memory` - (Optional) Virtual Machine Memory (in MB) allowed in `RUNNING` state. Defaults to `default quota`.
 * `running_vms` - (Optional) Number of Virtual Machines allowed in `RUNNING` state. Defaults to `default quota`.
 * `system_disk_size` - (Optional) Maximum disk global size (in MB) allowed on a `SYSTEM` datastore. Defaults to `default quota`.
+
+### Template section parameters
+
+`template_section` supports the following arguments:
+
+* `name` - (Optional) The vector name.
+* `elements` - (Optional) Collection of custom tags.
 
 ## Attribute Reference
 

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -69,6 +69,13 @@ resource "opennebula_virtual_machine" "example" {
   tags = {
     environment = "example"
   }
+
+  template_section {
+	  name = "test"
+	  elements = {
+		    key1 = "value1"
+	  }
+  }
 }
 ```
 
@@ -99,6 +106,7 @@ The following arguments are supported:
 * `lock` - (Optional) Lock the VM with a specific lock level. Supported values: `USE`, `MANAGE`, `ADMIN`, `ALL` or `UNLOCK`.
 * `on_disk_change` - (Optional) Select the behavior for changing disk images. Supported values: `RECREATE` or `SWAP` (default). `RECREATE` forces recreation of the vm and `SWAP` adopts the standard behavior of hot-swapping the disks. NOTE: This property does not affect the behavior of adding new disks.
 * `hard_shutdown` - (Optional) If the VM doesn't have ACPI support, it immediately poweroff/terminate/reboot/undeploy the VM. Defaults to false.
+* `template_section` - (Optional) Allow to add a custom vector. See [Template section parameters](#template-section-parameters)
 
 ### Graphics parameters
 
@@ -153,6 +161,13 @@ A NIC update will be triggered in adding or removing a `nic` section, or by a mo
 
 * `vmgroup_id` - (Required) ID of the VM group to use.
 * `role` - (Required) role of the VM group to use.
+
+### Template section parameters
+
+`template_section` supports the following arguments:
+
+* `name` - (Optional) The vector name.
+* `elements` - (Optional) Collection of custom tags.
 
 ## Attribute Reference
 

--- a/website/docs/r/virtual_machine_group.html.markdown
+++ b/website/docs/r/virtual_machine_group.html.markdown
@@ -30,6 +30,13 @@ resource "opennebula_virtual_machine_group" "example" {
   tags = {
     environment = "example"
   }
+
+  template_section {
+	  name = "test"
+	  elements = {
+		    key1 = "value1"
+	  }
+  }
 }
 ```
 
@@ -42,6 +49,7 @@ The following arguments are supported:
 * `role` - (Required) List of roles. See [Role parameters](#role-parameters) below for details.
 * `group` - (Optional) Name of the group which owns the virtual machine group. Defaults to the caller primary group.
 * `tags` - (Optional) Virtual Machine group tags.
+* `template_section` - (Optional) Allow to add a custom vector. See [Template section parameters](#template-section-parameters)
 
 ### Role parameters
 
@@ -51,6 +59,13 @@ The following arguments are supported:
 * `host_affined` - (Optional) List of Hosts affined to Virtual Machines using this role.
 * `host_anti_affined` - (Optional) List of Hosts not-affined to Virtual Machines using this role.
 * `policy` - (Optional) Policy to apply between Virtual Machines using this role. Allowed Values: `NONE`, `AFFINED`, `ANTI_AFFINED`.
+
+### Template section parameters
+
+`template_section` supports the following arguments:
+
+* `name` - (Optional) The vector name.
+* `elements` - (Optional) Collection of custom tags.
 
 ## Attribute Reference
 

--- a/website/docs/r/virtual_network.html.markdown
+++ b/website/docs/r/virtual_network.html.markdown
@@ -56,6 +56,13 @@ resource "opennebula_virtual_network" "example" {
   tags = {
     environment = "example"
   }
+
+  template_section {
+	  name = "test"
+	  elements = {
+		    key1 = "value1"
+	  }
+  }
 }
 ```
 
@@ -89,6 +96,7 @@ The following arguments are supported:
 * `group` - (Optional) Name of the group which owns the virtual network. Defaults to the caller primary group.
 * `tags` - (Optional) Virtual Network tags (Key = Value).
 * `lock` - (Optional) Lock the virtual network with a specific lock level. Supported values: `USE`, `MANAGE`, `ADMIN`, `ALL` or `UNLOCK`.
+* `template_section` - (Optional) Allow to add a custom vector. See [Template section parameters](#template-section-parameters)
 
 ### Address Range parameters
 
@@ -102,6 +110,13 @@ The following arguments are supported:
 * `global_prefix` - (Optional) Global prefix for `IP6` or `IP_4_6`.
 * `ula_prefix` - (Optional) ULA prefix for `IP6` or `IP_4_6`.
 * `prefix_length` - (Optional) Prefix length. Only needed for `IP6_STATIC` or `IP4_6_STATIC`
+
+### Template section parameters
+
+`template_section` supports the following arguments:
+
+* `name` - (Optional) The vector name.
+* `elements` - (Optional) Collection of custom tags.
 
 ## Attribute Reference
 

--- a/website/docs/r/virtual_router.html.markdown
+++ b/website/docs/r/virtual_router.html.markdown
@@ -26,6 +26,13 @@ resource "opennebula_virtual_router" "example" {
   tags = {
     environment = "example"
   }
+
+  template_section {
+	  name = "test"
+	  elements = {
+		    key1 = "value1"
+	  }
+  }
 }
 ```
 
@@ -39,6 +46,14 @@ The following arguments are supported:
 * `group` - (Optional) Name of the group which owns the virtual router. Defaults to the caller primary group.
 * `description` - (Optional) Description of the virtual router.
 * `lock` - (Optional) Lock the VM with a specific lock level. Supported values: `USE`, `MANAGE`, `ADMIN`, `ALL` or `UNLOCK`.
+* `template_section` - (Optional) Allow to add a custom vector. See [Template section parameters](#template-section-parameters)
+
+### Template section parameters
+
+`template_section` supports the following arguments:
+
+* `name` - (Optional) The vector name.
+* `elements` - (Optional) Collection of custom tags.
 
 ## Attribute Reference
 

--- a/website/docs/r/virtual_router_instance.markdown
+++ b/website/docs/r/virtual_router_instance.markdown
@@ -69,6 +69,13 @@ resource "opennebula_virtual_router_instance" "example" {
   tags = {
     environment = "example"
   }
+
+  template_section {
+	  name = "test1"
+	  elements = {
+		    key1 = "value1"
+	  }
+  }
 }
 ```
 
@@ -133,6 +140,13 @@ A disk update will be triggered in adding or removing a `disk` section, or by a 
 
 * `vmgroup_id` - (Required) ID of the VM group to use.
 * `role` - (Required) role of the VM group to use.
+
+### Template section parameters
+
+`template_section` supports the following arguments:
+
+* `name` - (Optional) The vector name.
+* `elements` - (Optional) Collection of custom tags.
 
 ## Attribute Reference
 

--- a/website/docs/r/virtual_router_instance_template.markdown
+++ b/website/docs/r/virtual_router_instance_template.markdown
@@ -40,6 +40,13 @@ resource "opennebula_virtual_router_instance_template" "example" {
   tags = {
     environment = "example"
   }
+
+    template_section {
+	  name = "test"
+	  elements = {
+		    key1 = "value1"
+	  }
+  }
 }
 ```
 
@@ -64,6 +71,7 @@ resource "opennebula_virtual_router_instance_template" "example" {
 * `sched_ds_requirements` - (Optional) Storage placement requirements to deploy the resource following specific rule.
 * `tags` - (Optional) Template tags (Key = Value).
 * `lock` - (Optional) Lock the template with a specific lock level. Supported values: `USE`, `MANAGE`, `ADMIN`, `ALL` or `UNLOCK`.
+* `template_section` - (Optional) Allow to add a custom vector. See [Template section parameters](#template-section-parameters)
 
 ### Graphics parameters
 
@@ -120,6 +128,13 @@ Minimum 1 item. Maximum 8 items.
 
 * `vmgroup_id` - (Required) ID of the VM group to use.
 * `role` - (Required) role of the VM group to use.
+
+### Template section parameters
+
+`template_section` supports the following arguments:
+
+* `name` - (Optional) The vector name.
+* `elements` - (Optional) Collection of custom tags.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

<!--- Please leave a helpful description of the PR here. --->
Until now, it's possible to pass custom (key=value) pairs to an OpenNebula resource via the provider.
However it doesn't allow to pass a custom vector (keyvec = [key=value, ... ] ).
The goal of this issue is to allow to pass custom vectors to resources.

Limitation: for simplicity it will be only possible to manage a vector with a unique name

### References

Close #359 

### New or Affected Resource(s)

<!--- Please list the new or affected resources and data sources. --->

- opennebula_group
TODO: all other resources

### Checklist

<!--- Please check you didn't forgot a step to help us merging this PR. --->

- [ ] I have created an issue and I have mentioned it in `References`
- [ ] My code follows the style guidelines of this project (use `go fmt`)
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the unit tests and they pass succesfuly
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation (if needed)
- [ ] I have updated the changelog file
