### PR TITLE
B-342: ignore default security group id from NIC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 BUG FIXES:
 
 * resources/opennebula_group: Add `opennebula` section (#358)
+* resource/opennebula_virtual_machine: Fix ignored NIC with `security_groups` configured (#342)
 
 # 1.0.1 (October 3rd, 2022)
 

--- a/opennebula/helpers_vm.go
+++ b/opennebula/helpers_vm.go
@@ -289,7 +289,22 @@ func vmNICAttach(ctx context.Context, vmc *goca.VMController, timeout time.Durat
 			for _, pair := range nicTpl.Pairs {
 
 				value, err := nic.GetStr(pair.Key())
-				if err != nil || value != pair.Value {
+				if pair.Key() == "SECURITY_GROUPS" {
+					// look for security group ID in the list
+					ids := strings.Split(value, ",")
+					found := false
+					for _, id := range ids {
+
+						if id != pair.Value {
+							continue
+						}
+						found = true
+						break
+					}
+					if !found {
+						continue loop
+					}
+				} else if err != nil || value != pair.Value {
 					continue loop
 				}
 

--- a/opennebula/resource_opennebula_virtual_machine_test.go
+++ b/opennebula/resource_opennebula_virtual_machine_test.go
@@ -1415,6 +1415,24 @@ resource "opennebula_virtual_machine" "test" {
 
 var testNICVNetResources = `
 
+resource "opennebula_security_group" "mysecgroup" {
+	name        = "secgroup"
+
+	rule {
+	  protocol  = "ALL"
+	  rule_type = "OUTBOUND"
+	}
+	rule {
+	  protocol  = "TCP"
+	  rule_type = "INBOUND"
+	  range     = "80"
+	}
+	rule {
+	  protocol  = "ICMP"
+	  rule_type = "INBOUND"
+	}
+  }
+
 resource "opennebula_virtual_network" "network1" {
 	name = "test-net1"
 	type            = "dummy"
@@ -1481,6 +1499,7 @@ resource "opennebula_virtual_machine" "test" {
 	nic {
 		network_id = opennebula_virtual_network.network1.id
 		ip = "172.16.100.131"
+		security_groups = [opennebula_security_group.mysecgroup.id]
 	}
 
 	timeout = 5
@@ -1520,6 +1539,7 @@ resource "opennebula_virtual_machine" "test" {
 	nic {
 		network_id = opennebula_virtual_network.network1.id
 		ip = "172.16.100.131"
+		security_groups = [opennebula_security_group.mysecgroup.id]
 	}
 	nic {
 		network_id = opennebula_virtual_network.network1.id
@@ -1563,6 +1583,7 @@ var testAccVirtualMachineTemplateConfigNICUpdate = testNICVNetResources + `
 	  nic {
 		network_id = opennebula_virtual_network.network1.id
 		ip = "172.16.100.131"
+		security_groups = [opennebula_security_group.mysecgroup.id]
 	  }
 	  nic {
 		network_id = opennebula_virtual_network.network2.id
@@ -1606,6 +1627,7 @@ var testAccVirtualMachineTemplateConfigNICIPUpdate = testNICVNetResources + `
 	  nic {
 		network_id = opennebula_virtual_network.network1.id
 		ip = "172.16.100.131"
+		security_groups = [opennebula_security_group.mysecgroup.id]
 	  }
 	  nic {
 		network_id = opennebula_virtual_network.network2.id


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

<!--- Please leave a helpful description of the PR here. --->
This PR make the provider ignore the default security group added by OpenNebula.
The provider didn't expect default value on cloud side and didn't recognized the configured NIC due to a diff with the configuration.

At the same time some `security_groups`  NIC field were added in the virtual machine NIC acceptance tests to make the problem appear. 

### References

Close #342 

### New or Affected Resource(s)

<!--- Please list the new or affected resources and data sources. --->

- opennebula_virtual_machine

### Checklist

<!--- Please check you didn't forgot a step to help us merging this PR. --->

- [ ] I have created an issue and I have mentioned it in `References`
- [ ] My code follows the style guidelines of this project (use `go fmt`)
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the unit tests and they pass succesfuly
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation (if needed)
- [ ] I have updated the changelog file
