### PR TITLE
B-312: vm import: read section when not configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ BUG FIXES:
 
 * resources/opennebula_datastore: fix system type values (#382)
 * resources/opennebula_host: fix host resource type case (#385)
+* resources/opennebula_virtual_machine: import more sections and attributes: `os`, `graphics`, `cpu_model`, `features`, `sched_requirements`, `sched_ds_requirements`, `description` (#377)
+* resources/opennebula_virtual_router_instance: import more sections and attributes: `os`, `graphics`, `cpu_model`, `features`, `sched_requirements`, `sched_ds_requirements`, `description` (#377)
+* resources/opennebula_template: import more sections and attributes: `os`, `graphics`, `cpu_model`, `features`, `sched_requirements`, `sched_ds_requirements`, `description` (#377)
+* resources/opennebula_virtual_router_instance_template: import more sections and attributes: `os`, `graphics`, `cpu_model`, `features`, `sched_requirements`, `sched_ds_requirements`, `description` (#377)
 
 # 1.1.0 (December 6th, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@ BUG FIXES:
 
 * resources/opennebula_datastore: fix system type values (#382)
 * resources/opennebula_host: fix host resource type case (#385)
-* resources/opennebula_virtual_machine: import more sections and attributes: `os`, `graphics`, `cpu_model`, `features`, `sched_requirements`, `sched_ds_requirements`, `description` (#377)
-* resources/opennebula_virtual_router_instance: import more sections and attributes: `os`, `graphics`, `cpu_model`, `features`, `sched_requirements`, `sched_ds_requirements`, `description` (#377)
+* resources/opennebula_virtual_machine: import more sections and attributes: `os`, `graphics`, `cpu_model`, `features`, `sched_requirements`, `sched_ds_requirements`, `description`, `template_id` (#377, #312)
+* resources/opennebula_virtual_router_instance: import more sections and attributes: `os`, `graphics`, `cpu_model`, `features`, `sched_requirements`, `sched_ds_requirements`, `description`, `template_id` (#377, #312)
 * resources/opennebula_template: import more sections and attributes: `os`, `graphics`, `cpu_model`, `features`, `sched_requirements`, `sched_ds_requirements`, `description` (#377)
 * resources/opennebula_virtual_router_instance_template: import more sections and attributes: `os`, `graphics`, `cpu_model`, `features`, `sched_requirements`, `sched_ds_requirements`, `description` (#377)
+* resources/opennebula_virtual_machine: set empty values instead of null for `template_disk`, `template_nic` (#312)
+* resources/opennebula_virtual_router_instance: set empty values instead of null for `template_disk`, `template_nic` (#312)
 
 # 1.1.0 (December 6th, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ BUG FIXES:
 * resources/opennebula_virtual_router_instance: import more sections and attributes: `os`, `graphics`, `cpu_model`, `features`, `sched_requirements`, `sched_ds_requirements`, `description`, `template_id` (#377, #312)
 * resources/opennebula_template: import more sections and attributes: `os`, `graphics`, `cpu_model`, `features`, `sched_requirements`, `sched_ds_requirements`, `description` (#377)
 * resources/opennebula_virtual_router_instance_template: import more sections and attributes: `os`, `graphics`, `cpu_model`, `features`, `sched_requirements`, `sched_ds_requirements`, `description` (#377)
-* resources/opennebula_virtual_machine: set empty values instead of null for `template_disk`, `template_nic` (#312)
-* resources/opennebula_virtual_router_instance: set empty values instead of null for `template_disk`, `template_nic` (#312)
+* resources/opennebula_virtual_machine: set empty values instead of null for `template_disk`, `template_nic`, `template_tags` (#312, #369)
+* resources/opennebula_virtual_router_instance: set empty values instead of null for `template_disk`, `template_nic`, `template_tags` (#312, #369)
 
 # 1.1.0 (December 6th, 2022)
 

--- a/opennebula/resource_opennebula_template.go
+++ b/opennebula/resource_opennebula_template.go
@@ -449,7 +449,7 @@ func resourceOpennebulaTemplateReadCustom(ctx context.Context, d *schema.Resourc
 		}
 	}
 
-	err = flattenTemplate(d, &tpl.Template)
+	err = flattenTemplate(d, nil, &tpl.Template)
 	if err != nil {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
@@ -459,7 +459,7 @@ func resourceOpennebulaTemplateReadCustom(ctx context.Context, d *schema.Resourc
 		return diags
 	}
 
-	err = flattenVMUserTemplate(d, meta, &tpl.Template.Template)
+	err = flattenVMUserTemplate(d, meta, nil, &tpl.Template.Template)
 	if err != nil {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,

--- a/opennebula/resource_opennebula_template_vm_group.go
+++ b/opennebula/resource_opennebula_template_vm_group.go
@@ -548,7 +548,6 @@ func resourceOpennebulaVMGroupUpdate(ctx context.Context, d *schema.ResourceData
 
 		update = true
 	}
-	log.Printf("[DEBUG] === 3 newTpl: %s", newTpl.String())
 
 	if update {
 		err = vmgc.Update(newTpl.String(), int(parameters.Replace))

--- a/opennebula/resource_opennebula_virtual_machine.go
+++ b/opennebula/resource_opennebula_virtual_machine.go
@@ -376,7 +376,7 @@ func resourceOpennebulaVirtualMachineCreate(ctx context.Context, d *schema.Resou
 			return diags
 		}
 
-		d.Set("template_tags", nil)
+		d.Set("template_tags", map[string]interface{}{})
 		d.Set("template_section_names", map[string]interface{}{})
 	}
 
@@ -623,6 +623,9 @@ func resourceOpennebulaVirtualMachineRead(ctx context.Context, d *schema.Resourc
 		}
 		if _, ok := d.GetOk("template_nic"); !ok {
 			d.Set("template_nic", []interface{}{})
+		}
+		if _, ok := d.GetOk("template_tags"); !ok {
+			d.Set("template_tags", map[string]interface{}{})
 		}
 
 		err := flattenVMDisk(d, &vmInfos.Template)

--- a/opennebula/resource_opennebula_virtual_machine.go
+++ b/opennebula/resource_opennebula_virtual_machine.go
@@ -613,6 +613,18 @@ func resourceOpennebulaVirtualMachineRead(ctx context.Context, d *schema.Resourc
 
 		var diags diag.Diagnostics
 
+		// read template ID from which the VM was created
+		templateID, _ := vmInfos.Template.GetInt("TEMPLATE_ID")
+		d.Set("template_id", templateID)
+
+		// add empty values for import
+		if _, ok := d.GetOk("template_disk"); !ok {
+			d.Set("template_disk", []interface{}{})
+		}
+		if _, ok := d.GetOk("template_nic"); !ok {
+			d.Set("template_nic", []interface{}{})
+		}
+
 		err := flattenVMDisk(d, &vmInfos.Template)
 		if err != nil {
 			diags = append(diags, diag.Diagnostic{

--- a/opennebula/resource_opennebula_virtual_router_instance.go
+++ b/opennebula/resource_opennebula_virtual_router_instance.go
@@ -45,11 +45,6 @@ func resourceOpennebulaVirtualRouterInstance() *schema.Resource {
 					Required:    true,
 					Description: "Identifier of the parent virtual router ressource",
 				},
-				"template_tags": {
-					Type:        schema.TypeMap,
-					Computed:    true,
-					Description: "When template_id was set this keeps the template tags.",
-				},
 			},
 		),
 	}
@@ -174,6 +169,16 @@ func resourceOpennebulaVirtualRouterInstanceCreate(ctx context.Context, d *schem
 	}
 
 	d.Set("template_tags", inheritedTags)
+
+	// save inherited template sections names
+	inheritedSectionsNames := make(map[string]interface{})
+	for _, e := range tpl.Template.Elements {
+		if vec, ok := e.(*dyn.Vector); ok {
+			inheritedSectionsNames[vec.Key()] = ""
+		}
+	}
+
+	d.Set("template_section_names", inheritedSectionsNames)
 
 	vrInfos, err = vrc.Info(false)
 	if err != nil {

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -184,7 +184,8 @@ The following attribute are exported:
 * `template_nic` - when `template_id` is used and the template define some NICs, this contains the template NICs description.
 * `tags_all` - Result of the applied `default_tags` and then resource `tags`.
 * `default_tags` - Default tags defined in the provider configuration.
-* `template_tags` - When template_id was set this keeps the template tags.
+* `template_tags` - When `template_id` was set this keeps the template tags.
+* `template_section_names` - When `template_id` was set this keeps the template section names only.
 
 ### Template NIC
 

--- a/website/docs/r/virtual_router_instance.markdown
+++ b/website/docs/r/virtual_router_instance.markdown
@@ -163,6 +163,7 @@ The following attribute are exported:
 * `tags_all` - Result of the applied `default_tags` and then resource `tags`.
 * `default_tags` - Default tags defined in the provider configuration.
 * `template_tags` - When `template_id` was set this keeps the template tags.
+* `template_section_names` - When `template_id` was set this keeps the template section names only.
 
 ### Template disk
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

<!--- Please leave a helpful description of the PR here. --->

This PR remove the constraint that condition reading of some cloud side parts: `OS`, `GRAPHICS`, `CPU_MODEL`, `FEATURES`, `SCHED_REQUIREMENTS`, `SCHED_DS_REQUIREMENTS`, `DESCRIPTION`.
Until now they are read only when configured, this avoid diffs when the VM is instantiated from a template and then inherit attributes.
I didn't add any `Computed` behavior (may lead to a diff if there is some default configuration made on cloud side).
This should allow a bit more helpful import of the virtual machine resource.

I also added some basic reading code in order to have less null fields in state (related to #312 and #369 ):
Until now `template_id`, `template_disk`, `template_nic`, template_tags are filled at virtual machine creation when instantiating a VM from a template. After that they don't change because they reflect the template used at the VM creation.

I add some reading code to import the `template_id` (in the VM there is a `TEMPLATE_ID` that I may use), however the template content may have changed so I won't fill `template_disk` and `template_nic`, and `template_tags`.

### References

Close #377
Close #312 
Close #369 

### New or Affected Resource(s)

<!--- Please list the new or affected resources and data sources. --->

- opennebula_virtual_machine
- opennebula_virtual_router_instance

### Checklist

<!--- Please check you didn't forgot a step to help us merging this PR. --->

- [ ] I have created an issue and I have mentioned it in `References`
- [ ] My code follows the style guidelines of this project (use `go fmt`)
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the unit tests and they pass succesfuly
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation (if needed)
- [ ] I have updated the changelog file
