### PR TITLE
B-389: cluster relationships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ BUG FIXES:
 * resources/opennebula_virtual_router_instance_template: import more sections and attributes: `os`, `graphics`, `cpu_model`, `features`, `sched_requirements`, `sched_ds_requirements`, `description` (#377)
 * resources/opennebula_virtual_machine: set empty values instead of null for `template_disk`, `template_nic`, `template_tags` (#312, #369)
 * resources/opennebula_virtual_router_instance: set empty values instead of null for `template_disk`, `template_nic`, `template_tags` (#312, #369)
+* resources/opennebula_host: add computed `cluster` attribute. (#389)
+* resources/opennebula_datastore: add computed `clusters` attribute. (#389)
+
+DEPRECATION:
+
+* resources/opennebula_host: deprecate `cluster_id` (#389)
+* resources/opennebula_datastore: deprecate `cluster_id` (#389)
+* resources/opennebula_virtual_network: deprecate `clusters` (#389)
+
 
 # 1.1.0 (December 6th, 2022)
 

--- a/opennebula/resource_opennebula_datastore.go
+++ b/opennebula/resource_opennebula_datastore.go
@@ -61,6 +61,15 @@ func resourceOpennebulaDatastore() *schema.Resource {
 				Optional:    true,
 				Default:     -1,
 				Description: "ID of the cluster",
+				Deprecated:  "manage membership from the datastores attribute of the cluster",
+			},
+			"clusters": {
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Description: "List of cluster IDs hosting the datastore",
+				Elem: &schema.Schema{
+					Type: schema.TypeInt,
+				},
 			},
 			"restricted_directories": {
 				Type:        schema.TypeString,
@@ -450,6 +459,7 @@ func resourceOpennebulaDatastoreRead(ctx context.Context, d *schema.ResourceData
 		}
 		d.Set("cluster_id", id)
 	}
+	d.Set("clusters", datastoreInfos.Clusters.ID)
 
 	restrictedDirs, err := datastoreInfos.Template.Get(dsKey.RestrictedDirs)
 	if err == nil {

--- a/opennebula/resource_opennebula_group_admins.go
+++ b/opennebula/resource_opennebula_group_admins.go
@@ -24,7 +24,7 @@ func resourceOpennebulaGroupAdmins() *schema.Resource {
 				Type:        schema.TypeInt,
 				Required:    true,
 				ForceNew:    true,
-				Description: "Name of the group",
+				Description: "ID of the group",
 			},
 			"users_ids": {
 				Type:        schema.TypeSet,
@@ -191,7 +191,7 @@ func resourceOpennebulaGroupAdminsDelete(ctx context.Context, d *schema.Resource
 	}
 	gc := controller.Group(int(groupID))
 
-	// add admins users_ids if list provided
+	// remove admins users_ids if list provided
 	adminsIDs := d.Get("users_ids").(*schema.Set).List()
 	for _, id := range adminsIDs {
 		err := gc.DelAdmin(id.(int))

--- a/opennebula/resource_opennebula_host.go
+++ b/opennebula/resource_opennebula_host.go
@@ -100,6 +100,12 @@ func resourceOpennebulaHost() *schema.Resource {
 				Optional:    true,
 				Default:     -1,
 				Description: "ID of the cluster",
+				Deprecated:  "manage membership from the hosts attribute of the cluster",
+			},
+			"cluster": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Cluster IDs hosting the host",
 			},
 			"tags":         tagsSchema(),
 			"default_tags": defaultTagsSchemaComputed(),
@@ -312,6 +318,7 @@ func resourceOpennebulaHostRead(ctx context.Context, d *schema.ResourceData, met
 
 	d.SetId(fmt.Sprintf("%v", hostInfos.ID))
 	d.Set("name", hostInfos.Name)
+	d.Set("cluster", hostInfos.ClusterID)
 
 	tags := make(map[string]interface{})
 	tagsAll := make(map[string]interface{})

--- a/opennebula/resource_opennebula_host_test.go
+++ b/opennebula/resource_opennebula_host_test.go
@@ -24,7 +24,6 @@ func TestAccHost(t *testing.T) {
 						"virtualization": "dummy",
 						"information":    "dummy",
 					}),
-					resource.TestCheckResourceAttr("opennebula_host.test1", "cluster_id", "0"),
 					resource.TestCheckResourceAttr("opennebula_host.test1", "tags.%", "2"),
 					resource.TestCheckResourceAttr("opennebula_host.test1", "tags.environment", "example"),
 					resource.TestCheckResourceAttr("opennebula_host.test1", "tags.test", "test"),
@@ -35,7 +34,6 @@ func TestAccHost(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("opennebula_host.test1", "name", "test-updated"),
 					resource.TestCheckResourceAttr("opennebula_host.test1", "type", "custom"),
-					resource.TestCheckResourceAttr("opennebula_host.test1", "cluster_id", "0"),
 					resource.TestCheckTypeSetElemNestedAttrs("opennebula_host.test1", "custom.*", map[string]string{
 						"virtualization": "dummy",
 						"information":    "dummy",
@@ -54,7 +52,6 @@ func TestAccHost(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("opennebula_host.test1", "name", "test-updated"),
 					resource.TestCheckResourceAttr("opennebula_host.test1", "type", "custom"),
-					resource.TestCheckResourceAttr("opennebula_host.test1", "cluster_id", "0"),
 					resource.TestCheckTypeSetElemNestedAttrs("opennebula_host.test1", "custom.*", map[string]string{
 						"virtualization": "dummy",
 						"information":    "dummy",
@@ -95,7 +92,6 @@ var testAccHostConfig = `
 resource "opennebula_host" "test1" {
 	name       = "test-custom"
 	type       = "custom"
-	cluster_id = 0
 
 	custom {
 		virtualization = "dummy"
@@ -113,7 +109,6 @@ var testAccHostConfigAddOvercommit = `
 resource "opennebula_host" "test1" {
 	name       = "test-updated"
 	type       = "custom"
-	cluster_id = 0
 
 	custom {
 		virtualization = "dummy"
@@ -136,7 +131,6 @@ var testAccHostConfigUpdate = `
 resource "opennebula_host" "test1" {
 	name       = "test-updated"
 	type       = "custom"
-	cluster_id = 0
 
 	custom {
 		virtualization = "dummy"

--- a/opennebula/resource_opennebula_virtual_network.go
+++ b/opennebula/resource_opennebula_virtual_network.go
@@ -136,11 +136,12 @@ func resourceOpennebulaVirtualNetwork() *schema.Resource {
 				Type:          schema.TypeSet,
 				Optional:      true,
 				Computed:      true,
-				Description:   "List of cluster IDs hosting the virtual Network, if not set it uses the default cluster",
+				Description:   "List of cluster IDs hosting the virtual Network",
 				ConflictsWith: []string{"reservation_vnet", "reservation_size", "reservation_ar_id", "reservation_first_ip"},
 				Elem: &schema.Schema{
 					Type: schema.TypeInt,
 				},
+				Deprecated: "manage membership from the virtual_networks attribute of the cluster",
 			},
 			"vlan_id": {
 				Type:          schema.TypeString,

--- a/website/docs/r/datastore.html.markdown
+++ b/website/docs/r/datastore.html.markdown
@@ -38,7 +38,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the datastore.
 * `type` - (Required) Type of the new datastore: image, system, file.
-* `cluster_id` - (Optional) ID of the cluster the datastore is part of.
+* `cluster_id` - (Deprecated) ID of the cluster the datastore is part of.
 * `restricted_directories` - (Optional) Paths that cannot be used to register images. A space separated list of paths.
 * `safe_directories` - (Optional) If you need to allow a directory listed under RESTRICTED_DIRS. A space separated list of paths.
 * `no_decompress` - (Optional) Boolean, do not try to untar or decompress the file to be registered.
@@ -86,6 +86,7 @@ The following attributes are exported:
 * `id` - ID of the datastore.
 * `tags_all` - Result of the applied `default_tags` and then resource `tags`.
 * `default_tags` - Default tags defined in the provider configuration.
+* `clusters` - List of cluster IDs hosting the datastore.  Manager cluster membership from `datastores` fields of the `cluster` resource instead.
 
 ## Import
 

--- a/website/docs/r/host.html.markdown
+++ b/website/docs/r/host.html.markdown
@@ -40,7 +40,6 @@ Create a custom host:
 resource "opennebula_host" "example" {
   name       = "test-kvm"
   type       = "custom"
-  cluster_id = 0
 
   custom = {
     virtualization = "custom"
@@ -60,7 +59,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the host.
 * `type` - (Required) Type of the new host: kvm, qemu, lxd, lxc, firecracker, custom. For now vcenter type is not managed by the provider.
-* `cluster_id` - (Optional) ID of the cluster the host is part of.
+* `cluster_id` - (Deprecated) ID of the cluster the host is part of.
 * `custom` - (Optional) If `type="custom"` this section should be defined, see [Custom](#custom) section for details.
 * `overcommit` - (Optional) This section allow to increase the allocatable capacity of the host. See [Overcommit](#overcommit)
 * `tags` - (Optional) Host tags (Key = value)
@@ -84,6 +83,7 @@ The following attributes are exported:
 * `id` - ID of the host.
 * `tags_all` - Result of the applied `default_tags` and then resource `tags`.
 * `default_tags` - Default tags defined in the provider configuration.
+* `cluster` - ID of the cluster hosting the host.  Manager cluster membership from `hosts` fields of the `cluster` resource instead.
 
 ## Import
 

--- a/website/docs/r/virtual_network.html.markdown
+++ b/website/docs/r/virtual_network.html.markdown
@@ -45,7 +45,6 @@ resource "opennebula_virtual_network" "example" {
   dns             = "172.16.100.1"
   gateway         = "172.16.100.1"
   security_groups = [0]
-  clusters        = [0]
 
   ar {
     ar_type = "IP4"
@@ -81,7 +80,7 @@ The following arguments are supported:
 * `bridge` - (Optional) Name of the bridge interface to which the virtual network should be associated. Conflicts with `reservation_vnet` and `reservation_size`.
 * `physical_device` - (Optional) Name of the physical device interface to which the virtual network should be associated. Conflicts with `reservation_vnet` and `reservation_size`.
 * `type` - (Optional) Virtual network type. One of these: `dummy`, `bridge`'`fw`, `ebtables`, `802.1Q`, `vxlan` or `ovswitch`. Defaults to `bridge`. Conflicts with `reservation_vnet` and `reservation_size`.
-* `clusters` - (Optional) List of cluster IDs where the virtual network can be use. Conflicts with `reservation_vnet` and `reservation_size`.
+* `clusters` - (Deprecated) List of cluster IDs where the virtual network can be use. Conflicts with `reservation_vnet` and `reservation_size`. Manager cluster membership from `virtual_networks` fields of the `cluster` resource instead.
 * `vlan_id` - (Optional) ID of VLAN. Only if `type` is `802.1Q`, `vxlan` or `ovswitch`. Conflicts with `reservation_vnet`, `reservation_size` and `automatic_vlan_id`.
 * `automatic_vlan_id` - (Optional) Flag to let OpenNebula scheduler to attribute the VLAN ID. Conflicts with `reservation_vnet`, `reservation_size` and `vlan_id`.
 * `mtu` - (Optional) Virtual network MTU. Defaults to `1500`. Conflicts with `reservation_vnet` and `reservation_size`.


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

<!--- Please leave a helpful description of the PR here. --->

Move cluster membership management for host, datastore and virtual_network exclusively on cluster resource side. 
If we go this way I'll want to update the provider for consistency on membership management (groups and users etc.)

### References

Close #389 

### New or Affected Resource(s)

<!--- Please list the new or affected resources and data sources. --->

- opennebula_cluster

### Checklist

<!--- Please check you didn't forgot a step to help us merging this PR. --->

- [ ] I have created an issue and I have mentioned it in `References`
- [ ] My code follows the style guidelines of this project (use `go fmt`)
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the unit tests and they pass succesfuly
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation (if needed)
- [ ] I have updated the changelog file
