### PR TITLE
B-382: conditional custom datastore reading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ BUG FIXES:
 * resources/opennebula_virtual_router_instance: set empty values instead of null for `template_disk`, `template_nic`, `template_tags` (#312, #369)
 * resources/opennebula_datastore: add argument `cluster_ids` (#389)
 * resources/opennebula_virtual_network: add argument `cluster_ids` (#389)
+* resources/opennebula_datastore: conditional reading of `datastore` argument from `custom`. (#382)
 
 DEPRECATION:
 

--- a/opennebula/resource_opennebula_datastore.go
+++ b/opennebula/resource_opennebula_datastore.go
@@ -610,10 +610,14 @@ func resourceOpennebulaDatastoreRead(ctx context.Context, d *schema.ResourceData
 		d.Set("ceph", []interface{}{cephAttrsMap})
 	} else if len(customAttrsList) > 0 {
 
-		d.Set("custom", []interface{}{map[string]interface{}{
-			"datastore": datastoreInfos.DSMad,
-			"transfer":  datastoreInfos.TMMad,
-		}})
+		customMap := map[string]interface{}{
+			"transfer": datastoreInfos.TMMad,
+		}
+
+		if datastoreInfos.DSMad != "-" {
+			customMap["datastore"] = datastoreInfos.DSMad
+		}
+		d.Set("custom", []interface{}{customMap})
 
 	}
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

<!--- Please leave a helpful description of the PR here. --->

From OpenNebula: ```SYSTEM datastores cannot have DS_MAD defined```

Setting datastore resource `type` to `system` imply that the `custom` `datastore` attribute (key `DS_MAD` in the XML) has `-` value.
In this case, the `datastore` value shouldn't be read.

### References

Close #382

### New or Affected Resource(s)

<!--- Please list the new or affected resources and data sources. --->

- opennebula_datastore

### Checklist

<!--- Please check you didn't forgot a step to help us merging this PR. --->

- [ ] I have created an issue and I have mentioned it in `References`
- [ ] My code follows the style guidelines of this project (use `go fmt`)
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the unit tests and they pass succesfuly
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation (if needed)
- [ ] I have updated the changelog file
