### PR TITLE
B #399: check overcommit not empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ BUG FIXES:
 * resources/opennebula_datastore: conditional reading of `datastore` argument from `custom`. (#382)
 * resources/opennebula_virtual_network_address_range: modify `hold_ips` content reading and introduce `helds_ips` attribute (#397)
 * resources/opennebula_virtual_network: for reservation, fix `type` and `reservation_ar_id` reading. (#397)
+* resources/opennebula_host: set overcommit map only when not empty (#399)
 
 DEPRECATION:
 

--- a/opennebula/resource_opennebula_host.go
+++ b/opennebula/resource_opennebula_host.go
@@ -343,7 +343,9 @@ func resourceOpennebulaHostRead(ctx context.Context, d *schema.ResourceData, met
 			overcommitMap["memory"] = hostInfos.Share.TotalMem - reservedMem
 		}
 
-		d.Set("overcommit", []map[string]interface{}{overcommitMap})
+		if len(overcommitMap) > 0 {
+			d.Set("overcommit", []map[string]interface{}{overcommitMap})
+		}
 	}
 
 	clusterID := d.Get("cluster_id").(int)


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

<!--- Please leave a helpful description of the PR here. --->
When creating an host with some overcommit fails just after the host creation in OpenNebula (after calling create method of the ONE API in the provider, we check the host state and then update the host content), overcommit wasn't configured in the host.

When reading the tainted host datas on cloud side, the provider was expecting to find `overcommit` attributes, so it begin to read overcommit values but wasn't able to found them.

The bug appears because we tried to set `overcommit` with an empty map

### References

Close #399

### New or Affected Resource(s)

<!--- Please list the new or affected resources and data sources. --->

- opennebula_host

### Checklist

<!--- Please check you didn't forgot a step to help us merging this PR. --->

- [ ] I have created an issue and I have mentioned it in `References`
- [ ] My code follows the style guidelines of this project (use `go fmt`)
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the unit tests and they pass succesfuly
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation (if needed)
- [ ] I have updated the changelog file
 