### PR TITLE
B-405: create ovswitch network without vlan id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 BUG FIXES:
 
 * resources/opennebula_virtual_machine: add transient state `LCM_INIT` (#410)
+* resources/opennebula_virtual_network: for `ovswitch` type the attributes `vlan_id` and `automatic_vlan_id` are optional (#405)
 
 NOTES:
 

--- a/opennebula/resource_opennebula_virtual_network.go
+++ b/opennebula/resource_opennebula_virtual_network.go
@@ -406,9 +406,8 @@ func changeVNetGroup(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func validVlanType(intype string) int {
-	vlanType := []string{"802.1Q", "vxlan", "ovswitch"}
-	return inArray(intype, vlanType)
+func mandatoryVLAN(intype string) bool {
+	return inArray(intype, []string{"802.1Q", "vxlan"}) >= 0
 }
 
 func resourceOpennebulaVirtualNetworkCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -804,7 +803,7 @@ func generateVn(d *schema.ResourceData) (string, error) {
 	tpl.Add(vnk.Name, vnname)
 	tpl.Add(vnk.VNMad, vnmad)
 
-	if validVlanType(vnmad) >= 0 {
+	if mandatoryVLAN(vnmad) {
 		if d.Get("automatic_vlan_id") == true {
 			tpl.Add("AUTOMATIC_VLAN_ID", "YES")
 		} else if vlanid, ok := d.GetOk("vlan_id"); ok {


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

<!--- Please leave a helpful description of the PR here. --->

Allows the virtual network creation without any `vlan_id` or `automatic_vlan_id` attributes provided.

### References

Close #405 

### New or Affected Resource(s)

<!--- Please list the new or affected resources and data sources. --->

- opennebula_virtual_network

### Checklist

<!--- Please check you didn't forgot a step to help us merging this PR. --->

- [ ] I have created an issue and I have mentioned it in `References`
- [ ] My code follows the style guidelines of this project (use `go fmt`)
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the unit tests and they pass succesfuly
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation (if needed)
- [ ] I have updated the changelog file
