### PR TITLE
B-312: read empty template_section_names for migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ BUG FIXES:
 
 * resources/opennebula_virtual_machine: add transient state `LCM_INIT` (#410)
 * resources/opennebula_virtual_network: for `ovswitch` type the attributes `vlan_id` and `automatic_vlan_id` are optional (#405)
+* resources/opennebula_virtual_machine: set empty values instead of null for `template_section_names` (#312)
 
 NOTES:
 

--- a/opennebula/resource_opennebula_virtual_machine.go
+++ b/opennebula/resource_opennebula_virtual_machine.go
@@ -627,6 +627,9 @@ func resourceOpennebulaVirtualMachineRead(ctx context.Context, d *schema.Resourc
 		if _, ok := d.GetOk("template_tags"); !ok {
 			d.Set("template_tags", map[string]interface{}{})
 		}
+		if _, ok := d.GetOk("template_section_names"); !ok {
+			d.Set("template_section_names", map[string]interface{}{})
+		}
 
 		err := flattenVMDisk(d, &vmInfos.Template)
 		if err != nil {


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

<!--- Please leave a helpful description of the PR here. --->

This read `template_section_names` computed attribute with an empty value when it's not already defined.
It should be filled by the provider itself at creation step, but when we update the provider release to 1.1.1 the create method is not called for already created VMs, and then this attribute is never read (and there a diff for each apply).

### References

#312 

### New or Affected Resource(s)

<!--- Please list the new or affected resources and data sources. --->

- opennebula_virtual_machine

### Checklist

<!--- Please check you didn't forgot a step to help us merging this PR. --->

- [ ] I have created an issue and I have mentioned it in `References`
- [ ] My code follows the style guidelines of this project (use `go fmt`)
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the unit tests and they pass succesfuly
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation (if needed)
- [ ] I have updated the changelog file
