### PR TITLE
B-410: add LCM_INIT transient state at VM creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 1.2.0 (Unreleased)
 
+BUG FIXES:
+
+* resources/opennebula_virtual_machine: add transient state `LCM_INIT` (#410)
+
 NOTES:
 
 * update the provider dependency on the terraform SDK 2 to the release v2.24.1

--- a/opennebula/helpers_vm_state.go
+++ b/opennebula/helpers_vm_state.go
@@ -24,7 +24,7 @@ var (
 	// Creation
 	vmCreateTransientStates = VMStates{
 		States: []vm.State{vm.Pending},
-		LCMs:   []vm.LCMState{vm.Prolog, vm.Boot},
+		LCMs:   []vm.LCMState{vm.LcmInit, vm.Prolog, vm.Boot},
 	}
 
 	// Deletion: terminate the VM


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

<!--- Please leave a helpful description of the PR here. --->

Add `LCM_INIT` as transient state at VM creation.

### References

Close #410 

### New or Affected Resource(s)

<!--- Please list the new or affected resources and data sources. --->

- opennebula_virtual_machine

### Checklist

<!--- Please check you didn't forgot a step to help us merging this PR. --->

- [ ] I have created an issue and I have mentioned it in `References`
- [ ] My code follows the style guidelines of this project (use `go fmt`)
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the unit tests and they pass succesfuly
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation (if needed)
- [ ] I have updated the changelog file
