### PR TITLE
B-427: read features in template resource only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ BUG FIXES:
 * resources/opennebula_virtual_machine:  rework diagnostics in read method and lower some severity levels (#425)
 * resources/opennebula_virtual_network:  rework diagnostics in read method and lower some severity levels (#425)
 * resources/opennebula_virtual_router_instance:  rework diagnostics in read method and lower some severity levels (#425)
+* resources/opennebula_virtual_machine: remove features section reading (#427)
 
 # 1.2.0 (March 23th, 2023)
 

--- a/opennebula/resource_opennebula_template.go
+++ b/opennebula/resource_opennebula_template.go
@@ -453,7 +453,17 @@ func resourceOpennebulaTemplateReadCustom(ctx context.Context, d *schema.Resourc
 	if err != nil {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
-			Summary:  "Failed to flatten",
+			Summary:  "Failed to flatten template",
+			Detail:   fmt.Sprintf("template (ID: %s): %s", d.Id(), err),
+		})
+		return diags
+	}
+
+	err = flattenFeatures(d, &tpl.Template)
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Failed to flatten features",
 			Detail:   fmt.Sprintf("template (ID: %s): %s", d.Id(), err),
 		})
 		return diags
@@ -495,6 +505,40 @@ func resourceOpennebulaTemplateReadCustom(ctx context.Context, d *schema.Resourc
 
 	if tpl.LockInfos != nil {
 		d.Set("lock", LockLevelToString(tpl.LockInfos.Locked))
+	}
+
+	return nil
+}
+
+func flattenFeatures(d *schema.ResourceData, tpl *vm.Template) error {
+	// Features
+	featuresMap := make([]map[string]interface{}, 0, 1)
+	pae, _ := tpl.GetFeature(vmk.PAE)
+	acpi, _ := tpl.GetFeature(vmk.ACPI)
+	apic, _ := tpl.GetFeature(vmk.APIC)
+	localtime, _ := tpl.GetFeature(vmk.LocalTime)
+	hyperv, _ := tpl.GetFeature("HYPERV")
+	guest_agent, _ := tpl.GetFeature(vmk.GuestAgent)
+	virtio_scsi_queues, _ := tpl.GetFeature(vmk.VirtIOScsiQueues)
+	iothreads, _ := tpl.GetFeature("IOTHREADS")
+
+	// Set features to resource
+	if pae != "" || acpi != "" || apic != "" || localtime != "" || hyperv != "" || guest_agent != "" || virtio_scsi_queues != "" || iothreads != "" {
+		featuresMap = append(featuresMap, map[string]interface{}{
+			"pae":                pae,
+			"acpi":               acpi,
+			"apic":               apic,
+			"localtime":          localtime,
+			"hyperv":             hyperv,
+			"guest_agent":        guest_agent,
+			"virtio_scsi_queues": virtio_scsi_queues,
+			"iothreads":          iothreads,
+		})
+
+		err := d.Set("features", featuresMap)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/opennebula/shared_schemas.go
+++ b/opennebula/shared_schemas.go
@@ -768,18 +768,6 @@ func flattenTemplate(d *schema.ResourceData, inheritedVectors map[string]interfa
 	port, _ := vmTemplate.GetIOGraphic(vmk.Port)
 	t, _ := vmTemplate.GetIOGraphic(vmk.GraphicType)
 	keymap, _ := vmTemplate.GetIOGraphic(vmk.Keymap)
-	// Features
-	featuresMap := make([]map[string]interface{}, 0, 1)
-	pae, _ := vmTemplate.GetFeature(vmk.PAE)
-	acpi, _ := vmTemplate.GetFeature(vmk.ACPI)
-	apic, _ := vmTemplate.GetFeature(vmk.APIC)
-	localtime, _ := vmTemplate.GetFeature(vmk.LocalTime)
-	// not using vmk here because key not defined yet:
-	hyperv, _ := vmTemplate.GetFeature("HYPERV")
-	guest_agent, _ := vmTemplate.GetFeature(vmk.GuestAgent)
-	virtio_scsi_queues, _ := vmTemplate.GetFeature(vmk.VirtIOScsiQueues)
-	// not using vmk here because key not defined yet:
-	iothreads, _ := vmTemplate.GetFeature("IOTHREADS")
 
 	// VM size
 	cpu, _ := vmTemplate.GetCPU()
@@ -847,27 +835,6 @@ func flattenTemplate(d *schema.ResourceData, inheritedVectors map[string]interfa
 		_, inherited := inheritedVectors["GRAPHICS"]
 		if !inherited {
 			err = d.Set("graphics", graphMap)
-			if err != nil {
-				return err
-			}
-		}
-	}
-
-	// Set features to resource
-	if pae != "" || acpi != "" || apic != "" || localtime != "" || hyperv != "" || guest_agent != "" || virtio_scsi_queues != "" || iothreads != "" {
-		featuresMap = append(featuresMap, map[string]interface{}{
-			"pae":                pae,
-			"acpi":               acpi,
-			"apic":               apic,
-			"localtime":          localtime,
-			"hyperv":             hyperv,
-			"guest_agent":        guest_agent,
-			"virtio_scsi_queues": virtio_scsi_queues,
-			"iothreads":          iothreads,
-		})
-		_, inherited := inheritedVectors["FEATURES"]
-		if !inherited {
-			err = d.Set("features", featuresMap)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

<!--- Please leave a helpful description of the PR here. --->

`features` is read by the virtual machine resource, it's wrong because the `features` schema section is only defined in template resource.

### References

Close #427 

### New or Affected Resource(s)

<!--- Please list the new or affected resources and data sources. --->

- opennebula_virtual_machine

### Checklist

<!--- Please check you didn't forgot a step to help us merging this PR. --->

- [ ] I have created an issue and I have mentioned it in `References`
- [ ] My code follows the style guidelines of this project (use `go fmt`)
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the unit tests and they pass succesfuly
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation (if needed)
- [ ] I have updated the changelog file
