### PR TITLE
B-436: fix virtual network resource import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ BUG FIXES:
 * resources/opennebula_virtual_network:  rework diagnostics in read method and lower some severity levels (#425)
 * resources/opennebula_virtual_router_instance:  rework diagnostics in read method and lower some severity levels (#425)
 * resources/opennebula_virtual_machine: remove features section reading (#427)
+* resources/opennebula_virtual_network: fix import (#436)
 
 # 1.2.0 (March 23th, 2023)
 

--- a/opennebula/resource_opennebula_virtual_network.go
+++ b/opennebula/resource_opennebula_virtual_network.go
@@ -945,7 +945,7 @@ func resourceOpennebulaVirtualNetworkRead(ctx context.Context, d *schema.Resourc
 	}
 
 	// in case this vnet is a reservation
-	if reservationVNet > -1 {
+	if reservationVNet > -1 && len(vn.ParentNetworkID) > 0 {
 		parentNetworkID, err := strconv.ParseInt(vn.ParentNetworkID, 10, 0)
 		if err != nil {
 			diags = append(diags, diag.Diagnostic{


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

<!--- Please leave a helpful description of the PR here. --->
Fix virtual network resource import, only checking the `reservation_vnet` is not enough: it doesn't take it's default value (-1) when we import

### References

#436 

### New or Affected Resource(s)

<!--- Please list the new or affected resources and data sources. --->

- opennebula_virtual_network

### Checklist

<!--- Please check you didn't forgot a step to help us merging this PR. --->

- [ ] I have created an issue and I have mentioned it in `References`
- [ ] My code follows the style guidelines of this project (use `go fmt`)
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the unit tests and they pass succesfuly
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation (if needed)
- [ ] I have updated the changelog file
