### PR TITLE
B-440: fix removed error checks

### DIFF
--- a/opennebula/resource_opennebula_group.go
+++ b/opennebula/resource_opennebula_group.go
@@ -456,11 +456,13 @@ func flattenGroupTemplate(d *schema.ResourceData, meta interface{}, groupTpl *dy
 				}
 
 				err := d.Set("sunstone", []interface{}{sunstoneConfig})
-				diags = append(diags, diag.Diagnostic{
-					Severity: diag.Warning,
-					Summary:  "Failed to find vector",
-					Detail:   fmt.Sprintf("group (ID: %s): %s", d.Id(), err),
-				})
+				if err != nil {
+					diags = append(diags, diag.Diagnostic{
+						Severity: diag.Warning,
+						Summary:  "Failed to find vector",
+						Detail:   fmt.Sprintf("group (ID: %s): %s", d.Id(), err),
+					})
+				}
 			case "OPENNEBULA":
 
 				opennebulaConfig := make(map[string]interface{})
@@ -481,11 +483,13 @@ func flattenGroupTemplate(d *schema.ResourceData, meta interface{}, groupTpl *dy
 				}
 
 				err := d.Set("opennebula", []interface{}{opennebulaConfig})
-				diags = append(diags, diag.Diagnostic{
-					Severity: diag.Warning,
-					Summary:  "Failed to find vector",
-					Detail:   fmt.Sprintf("group (ID: %s): %s", d.Id(), err),
-				})
+				if err != nil {
+					diags = append(diags, diag.Diagnostic{
+						Severity: diag.Warning,
+						Summary:  "Failed to find vector",
+						Detail:   fmt.Sprintf("group (ID: %s): %s", d.Id(), err),
+					})
+				}
 			default:
 				log.Printf("[DEBUG] ignored: %s", e)
 			}


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

<!--- Please leave a helpful description of the PR here. --->
During code refactoring some error checks were accidentally removed, the result is that some warning appears when using `sunstone`, and `opennebula` vector in the group resource.

### References

close #440 

### New or Affected Resource(s)

<!--- Please list the new or affected resources and data sources. --->

- opennebula_group

### Checklist

<!--- Please check you didn't forgot a step to help us merging this PR. --->

- [ ] I have created an issue and I have mentioned it in `References`
- [ ] My code follows the style guidelines of this project (use `go fmt`)
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the unit tests and they pass succesfuly
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation (if needed)
- [ ] I have updated the changelog file
