### PR TITLE
B-445: check if flow client is not nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ BUG FIXES:
   * `mtu`, `guest_mtu`, `description`, `gateway`, `network_mask`, `network_address`, `search_domain`, `dns` are not marked as `computed` and are not read for a reservation virtual network
   * `gateway`, `network_mask`, `network_address`, `search_domain`, `dns` are now read by the provider
   * When not used more emtpy values are set for attributes
+* resources/opennebula_service: check if flow client is nil (#445)
+* resources/opennebula_service_template: check if flow client is nil (#445)
 
 # 1.2.0 (March 23th, 2023)
 

--- a/opennebula/provider.go
+++ b/opennebula/provider.go
@@ -118,6 +118,10 @@ type Configuration struct {
 	newDefaultTags map[string]interface{}
 }
 
+func (c *Configuration) isFlowConfigured() bool {
+	return c.Controller.ClientFlow != nil
+}
+
 func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 
 	var diags diag.Diagnostics

--- a/opennebula/resource_opennebula_service.go
+++ b/opennebula/resource_opennebula_service.go
@@ -148,9 +148,19 @@ func resourceOpennebulaServiceCreate(ctx context.Context, d *schema.ResourceData
 	config := meta.(*Configuration)
 	controller := config.Controller
 
+	var diags diag.Diagnostics
+
+	if !config.isFlowConfigured() {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Flow client isn't configured",
+			Detail:   fmt.Sprintf("Check flow_endpoint in the provider configuration"),
+		})
+		return diags
+	}
+
 	var err error
 	var serviceID int
-	var diags diag.Diagnostics
 
 	// if template id is set, instantiate a Service from this template
 	tc := controller.STemplate(d.Get("template_id").(int))
@@ -240,7 +250,18 @@ func resourceOpennebulaServiceCreate(ctx context.Context, d *schema.ResourceData
 
 func resourceOpennebulaServiceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 
+	config := meta.(*Configuration)
+
 	var diags diag.Diagnostics
+
+	if !config.isFlowConfigured() {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Flow client isn't configured",
+			Detail:   fmt.Sprintf("Check flow_endpoint in the provider configuration"),
+		})
+		return diags
+	}
 
 	sc, err := getServiceController(d, meta)
 	if err != nil {
@@ -312,7 +333,18 @@ func resourceOpennebulaServiceRead(ctx context.Context, d *schema.ResourceData, 
 
 func resourceOpennebulaServiceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 
+	config := meta.(*Configuration)
+
 	var diags diag.Diagnostics
+
+	if !config.isFlowConfigured() {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Flow client isn't configured",
+			Detail:   fmt.Sprintf("Check flow_endpoint in the provider configuration"),
+		})
+		return diags
+	}
 
 	//Get Service
 	sc, err := getServiceController(d, meta)
@@ -376,10 +408,20 @@ func resourceOpennebulaServiceExists(d *schema.ResourceData, meta interface{}) (
 }
 
 func resourceOpennebulaServiceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+
 	config := meta.(*Configuration)
 	controller := config.Controller
 
 	var diags diag.Diagnostics
+
+	if !config.isFlowConfigured() {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Flow client isn't configured",
+			Detail:   fmt.Sprintf("Check flow_endpoint in the provider configuration"),
+		})
+		return diags
+	}
 
 	//Get Service controller
 	sc, err := getServiceController(d, meta)

--- a/opennebula/resource_opennebula_service_template.go
+++ b/opennebula/resource_opennebula_service_template.go
@@ -116,6 +116,15 @@ func resourceOpennebulaServiceTemplateCreate(ctx context.Context, d *schema.Reso
 
 	var diags diag.Diagnostics
 
+	if !config.isFlowConfigured() {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Flow client isn't configured",
+			Detail:   fmt.Sprintf("Check flow_endpoint in the provider configuration"),
+		})
+		return diags
+	}
+
 	// Marshall the json
 	stemplate := &srv_tmpl.ServiceTemplate{}
 	err := json.Unmarshal([]byte(d.Get("template").(string)), stemplate)
@@ -195,8 +204,18 @@ func resourceOpennebulaServiceTemplateCreate(ctx context.Context, d *schema.Reso
 }
 
 func resourceOpennebulaServiceTemplateRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Configuration)
 
 	var diags diag.Diagnostics
+
+	if !config.isFlowConfigured() {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Flow client isn't configured",
+			Detail:   fmt.Sprintf("Check flow_endpoint in the provider configuration"),
+		})
+		return diags
+	}
 
 	stc, err := getServiceTemplateController(d, meta)
 	if err != nil {
@@ -251,7 +270,18 @@ func resourceOpennebulaServiceTemplateRead(ctx context.Context, d *schema.Resour
 
 func resourceOpennebulaServiceTemplateDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 
+	config := meta.(*Configuration)
+
 	var diags diag.Diagnostics
+
+	if !config.isFlowConfigured() {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Flow client isn't configured",
+			Detail:   fmt.Sprintf("Check flow_endpoint in the provider configuration"),
+		})
+		return diags
+	}
 
 	//Get Service
 	stc, err := getServiceTemplateController(d, meta)
@@ -301,6 +331,15 @@ func resourceOpennebulaServiceTemplateUpdate(ctx context.Context, d *schema.Reso
 	controller := config.Controller
 
 	var diags diag.Diagnostics
+
+	if !config.isFlowConfigured() {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Flow client isn't configured",
+			Detail:   fmt.Sprintf("Check flow_endpoint in the provider configuration"),
+		})
+		return diags
+	}
 
 	//Get Service controller
 	stc, err := getServiceTemplateController(d, meta)


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

<!--- Please leave a helpful description of the PR here. --->

In CRUD methods of service and service_template resources, check if the flow client is not nil to avoid the provider to crash

### References

#445

### New or Affected Resource(s)

<!--- Please list the new or affected resources and data sources. --->

- opennebula_service
- opennebula_service_template

### Checklist

<!--- Please check you didn't forgot a step to help us merging this PR. --->

- [ ] I have created an issue and I have mentioned it in `References`
- [ ] My code follows the style guidelines of this project (use `go fmt`)
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the unit tests and they pass succesfuly
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation (if needed)
- [ ] I have updated the changelog file
