### PR TITLE
F-447 F-448: externalize quotas as resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# 1.3.0 (Unreleased)
+
+FEATURES:
+
+* **New Resource**: `opennebula_user_quotas` (#448)
+* **New Resource**: `opennebula_group_quotas` (#447)
+
+DEPRECATION:
+
+* `quotas` section of `opennebula_user` resource (#448)
+* `quotas` section of `opennebula_group` resource (#447)
+
+# 1.2.2 (Unreleased)
+
 # 1.2.2 (May 31st, 2023)
 
 BUG FIXES:

--- a/opennebula/deprecated_quotas.go
+++ b/opennebula/deprecated_quotas.go
@@ -1,0 +1,322 @@
+package opennebula
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	dyn "github.com/OpenNebula/one/src/oca/go/src/goca/dynamic"
+	"github.com/OpenNebula/one/src/oca/go/src/goca/schemas/shared"
+)
+
+const (
+	oldDSFlag  uint8 = 1
+	oldNetFlag       = 2
+	oldVMFlag        = 4
+	oldImgFlag       = 8
+)
+
+func oldQuotasSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeSet,
+		Optional:    true,
+		Description: "Define user quota",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"datastore_quotas": {
+					Type:        schema.TypeList,
+					Optional:    true,
+					Description: "Datastore quotas",
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"id": {
+								Type:        schema.TypeInt,
+								Required:    true,
+								Description: "Datastore ID",
+							},
+							"images": {
+								Type:        schema.TypeInt,
+								Optional:    true,
+								Description: "Maximum number of Images allowed (default: default quota)",
+								Default:     -1,
+							},
+							"size": {
+								Type:        schema.TypeInt,
+								Optional:    true,
+								Description: "Maximum size in MB allowed on the datastore (default: default quota)",
+								Default:     -1,
+							},
+						},
+					},
+				},
+				"network_quotas": {
+					Type:        schema.TypeList,
+					Optional:    true,
+					Description: "Network quotas",
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"id": {
+								Type:        schema.TypeInt,
+								Required:    true,
+								Description: "Network ID",
+							},
+							"leases": {
+								Type:        schema.TypeInt,
+								Optional:    true,
+								Description: "Maximum number of Leases allowed for this network (default: default quota)",
+								Default:     -1,
+							},
+						},
+					},
+				},
+				"image_quotas": {
+					Type:        schema.TypeList,
+					Optional:    true,
+					Description: "Image quotas",
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"id": {
+								Type:        schema.TypeInt,
+								Required:    true,
+								Description: "Image ID",
+							},
+							"running_vms": {
+								Type:        schema.TypeInt,
+								Optional:    true,
+								Description: "Maximum number of Running VMs allowed for this image (default: default quota)",
+								Default:     -1,
+							},
+						},
+					},
+				},
+				"vm_quotas": {
+					Type:        schema.TypeList,
+					Optional:    true,
+					Description: "VM quotas",
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"cpu": {
+								Type:        schema.TypeFloat,
+								Optional:    true,
+								Description: "Maximum number of CPU allowed (default: default quota)",
+								Default:     -1,
+							},
+							"memory": {
+								Type:        schema.TypeInt,
+								Optional:    true,
+								Description: "Maximum Memory (MB) allowed (default: default quota)",
+								Default:     -1,
+							},
+							"running_cpu": {
+								Type:        schema.TypeFloat,
+								Optional:    true,
+								Description: "Maximum number of 'running' CPUs allowed (default: default quota)",
+								Default:     -1,
+							},
+							"running_memory": {
+								Type:        schema.TypeInt,
+								Optional:    true,
+								Description: "'Running' Memory (MB) allowed (default: default quota)",
+								Default:     -1,
+							},
+							"running_vms": {
+								Type:        schema.TypeInt,
+								Optional:    true,
+								Description: "Maximum number of Running VMs allowed (default: default quota)",
+								Default:     -1,
+							},
+							"system_disk_size": {
+								Type:        schema.TypeInt,
+								Optional:    true,
+								Description: "Maximum System Disk size (MB) allowed (default: default quota)",
+								Default:     -1,
+							},
+							"vms": {
+								Type:        schema.TypeInt,
+								Optional:    true,
+								Description: "Maximum number of VMs allowed (default: default quota)",
+								Default:     -1,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func generateOldQuotas(d *schema.ResourceData) (string, error) {
+	quotas := d.Get("quotas").(*schema.Set).List()
+
+	tpl := dyn.NewTemplate()
+
+	quotasMap := quotas[0].(map[string]interface{})
+	datastore := quotasMap["datastore_quotas"].([]interface{})
+	network := quotasMap["network_quotas"].([]interface{})
+	image := quotasMap["image_quotas"].([]interface{})
+	vm := quotasMap["vm_quotas"].([]interface{})
+
+	for i := 0; i < len(datastore); i++ {
+		datastoreTpl := tpl.AddVector("DATASTORE")
+
+		datastoreMap := datastore[i].(map[string]interface{})
+
+		datastoreTpl.AddPair("ID", datastoreMap["id"].(int))
+		if datastoreMap["images"].(int) == -1 {
+			if datastoreMap["size"].(int) == -1 {
+				return "", fmt.Errorf("can't build datastore quota, images or size must be defined\n")
+			}
+		} else {
+			datastoreTpl.AddPair("IMAGES", datastoreMap["images"].(int))
+		}
+		if datastoreMap["size"].(int) != -1 {
+			datastoreTpl.AddPair("SIZE", datastoreMap["size"].(int))
+		}
+	}
+
+	for i := 0; i < len(network); i++ {
+		networkTpl := tpl.AddVector("NETWORK")
+
+		networkMap := network[i].(map[string]interface{})
+
+		networkTpl.AddPair("ID", networkMap["id"].(int))
+
+		if networkMap["leases"].(int) != -1 {
+			networkTpl.AddPair("LEASES", networkMap["leases"].(int))
+		} else {
+			return "", fmt.Errorf("can't build network quota, leases must be defined\n")
+		}
+	}
+
+	for i := 0; i < len(image); i++ {
+		imageTpl := tpl.AddVector("IMAGE")
+
+		imageMap := image[i].(map[string]interface{})
+
+		imageTpl.AddPair("ID", imageMap["id"].(int))
+
+		if imageMap["running_vms"].(int) != -1 {
+			imageTpl.AddPair("RVMS", imageMap["running_vms"].(int))
+		} else {
+			return "", fmt.Errorf("can't build image quota, running_vms must be defined\n")
+		}
+	}
+
+	if len(vm) > 0 {
+		vmMap := vm[0].(map[string]interface{})
+
+		vmTpl := tpl.AddVector("VM")
+
+		if vmMap["cpu"].(float64) != -1.0 {
+			vmTpl.AddPair("CPU", float32(vmMap["cpu"].(float64)))
+		}
+		if vmMap["memory"].(int) != -1 {
+			vmTpl.AddPair("MEMORY", vmMap["memory"].(int))
+		}
+		if vmMap["running_cpu"].(float64) != -1.0 {
+			vmTpl.AddPair("RUNNING_CPU", float32(vmMap["running_cpu"].(float64)))
+		}
+		if vmMap["running_memory"].(int) != -1 {
+			vmTpl.AddPair("RUNNING_MEMORY", vmMap["running_memory"].(int))
+		}
+		if vmMap["running_vms"].(int) != -1 {
+			vmTpl.AddPair("RUNNING_VMS", vmMap["running_vms"].(int))
+		}
+		if vmMap["system_disk_size"].(int) != -1 {
+			vmTpl.AddPair("SYSTEM_DISK_SIZE", vmMap["system_disk_size"].(int))
+		}
+		if vmMap["vms"].(int) != -1 {
+			vmTpl.AddPair("VMS", vmMap["vms"].(int))
+		}
+	}
+
+	tplStr := tpl.String()
+
+	log.Printf("[INFO] Quotas definition: %s", tplStr)
+	return tplStr, nil
+}
+
+func flattenOldQuotasMapFromStructs(d *schema.ResourceData, quotas *shared.QuotasList) error {
+	var datastoreQuotas []map[string]interface{}
+	var imageQuotas []map[string]interface{}
+	var vmQuotas []map[string]interface{}
+	var networkQuotas []map[string]interface{}
+	var q uint8
+	q = 0
+
+	// Get datastore quotas
+	for _, qds := range quotas.Datastore {
+		ds := make(map[string]interface{})
+		ds["id"] = qds.ID
+		ds["images"] = qds.Images
+		ds["size"] = qds.Size
+		if len(ds) > 0 {
+			datastoreQuotas = append(datastoreQuotas, ds)
+		}
+		q = q | DSFlag
+	}
+	// Get network quotas
+	for _, qn := range quotas.Network {
+		n := make(map[string]interface{})
+		n["id"] = qn.ID
+		n["leases"] = qn.Leases
+		if len(n) > 0 {
+			networkQuotas = append(networkQuotas, n)
+		}
+		q = q | NetFlag
+	}
+	// Get VM quotas
+	if quotas.VM != nil {
+		vm := make(map[string]interface{})
+
+		vm["cpu"] = quotas.VM.CPU
+		vm["memory"] = quotas.VM.Memory
+		vm["running_cpu"] = quotas.VM.RunningCPU
+		vm["running_memory"] = quotas.VM.RunningMemory
+		vm["vms"] = quotas.VM.VMs
+		vm["running_vms"] = quotas.VM.RunningVMs
+		vm["system_disk_size"] = quotas.VM.SystemDiskSize
+
+		if len(vm) > 0 {
+			vmQuotas = append(vmQuotas, vm)
+		}
+		q = q | VMFlag
+	}
+	// Get Image quotas
+	for _, qimg := range quotas.Image {
+		img := make(map[string]interface{})
+		img["id"] = qimg.ID
+		img["running_vms"] = qimg.RVMs
+		if len(img) > 0 {
+			imageQuotas = append(imageQuotas, img)
+		}
+		q = q | ImgFlag
+	}
+
+	quotasMap := make(map[string]interface{}, 0)
+	for q > 0 {
+		switch {
+		case q&DSFlag > 0:
+			quotasMap["datastore_quotas"] = datastoreQuotas
+			q = q ^ DSFlag
+		case q&NetFlag > 0:
+			quotasMap["network_quotas"] = networkQuotas
+			q = q ^ NetFlag
+		case q&VMFlag > 0:
+			quotasMap["vm_quotas"] = vmQuotas
+			q = q ^ VMFlag
+		case q&ImgFlag > 0:
+			quotasMap["image_quotas"] = imageQuotas
+			q = q ^ ImgFlag
+		}
+	}
+
+	if len(quotasMap) > 0 {
+		return d.Set("quotas", []interface{}{
+			quotasMap,
+		})
+	} else {
+		return nil
+	}
+}

--- a/opennebula/provider.go
+++ b/opennebula/provider.go
@@ -84,11 +84,13 @@ func Provider() *schema.Provider {
 		ResourcesMap: map[string]*schema.Resource{
 			"opennebula_acl":                              resourceOpennebulaACL(),
 			"opennebula_group":                            resourceOpennebulaGroup(),
+			"opennebula_group_quotas":                     resourceOpennebulaGroupQuotas(),
 			"opennebula_group_admins":                     resourceOpennebulaGroupAdmins(),
 			"opennebula_image":                            resourceOpennebulaImage(),
 			"opennebula_security_group":                   resourceOpennebulaSecurityGroup(),
 			"opennebula_template":                         resourceOpennebulaTemplate(),
 			"opennebula_user":                             resourceOpennebulaUser(),
+			"opennebula_user_quotas":                      resourceOpennebulaUserQuotas(),
 			"opennebula_virtual_data_center":              resourceOpennebulaVirtualDataCenter(),
 			"opennebula_virtual_machine":                  resourceOpennebulaVirtualMachine(),
 			"opennebula_virtual_network":                  resourceOpennebulaVirtualNetwork(),

--- a/opennebula/quotas.go
+++ b/opennebula/quotas.go
@@ -1,7 +1,6 @@
 package opennebula
 
 import (
-	"fmt"
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -11,134 +10,129 @@ import (
 )
 
 const (
+	DefaultQuotaValue = -1
+
 	DSFlag  uint8 = 1
 	NetFlag       = 2
 	VMFlag        = 4
 	ImgFlag       = 8
 )
 
-func quotasSchema() *schema.Schema {
-	return &schema.Schema{
-		Type:        schema.TypeSet,
-		Optional:    true,
-		Description: "Define user quota",
-		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{
-				"datastore_quotas": {
-					Type:        schema.TypeList,
-					Optional:    true,
-					Description: "Datastore quotas",
-					Elem: &schema.Resource{
-						Schema: map[string]*schema.Schema{
-							"id": {
-								Type:        schema.TypeInt,
-								Required:    true,
-								Description: "Datastore ID",
-							},
-							"images": {
-								Type:        schema.TypeInt,
-								Optional:    true,
-								Description: "Maximum number of Images allowed (default: default quota)",
-								Default:     -1,
-							},
-							"size": {
-								Type:        schema.TypeInt,
-								Optional:    true,
-								Description: "Maximum size in MB allowed on the datastore (default: default quota)",
-								Default:     -1,
-							},
-						},
+func quotasMapSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"datastore": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "Datastore quotas",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"id": {
+						Type:        schema.TypeInt,
+						Required:    true,
+						Description: "Datastore ID",
+					},
+					"images": {
+						Type:        schema.TypeInt,
+						Optional:    true,
+						Description: "Maximum number of Images allowed (default: default quota)",
+						Default:     -1,
+					},
+					"size": {
+						Type:        schema.TypeInt,
+						Optional:    true,
+						Description: "Maximum size in MB allowed on the datastore (default: default quota)",
+						Default:     DefaultQuotaValue,
 					},
 				},
-				"network_quotas": {
-					Type:        schema.TypeList,
-					Optional:    true,
-					Description: "Network quotas",
-					Elem: &schema.Resource{
-						Schema: map[string]*schema.Schema{
-							"id": {
-								Type:        schema.TypeInt,
-								Required:    true,
-								Description: "Network ID",
-							},
-							"leases": {
-								Type:        schema.TypeInt,
-								Optional:    true,
-								Description: "Maximum number of Leases allowed for this network (default: default quota)",
-								Default:     -1,
-							},
-						},
+			},
+		},
+		"network": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "Network quotas",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"id": {
+						Type:        schema.TypeInt,
+						Required:    true,
+						Description: "Network ID",
+					},
+					"leases": {
+						Type:        schema.TypeInt,
+						Optional:    true,
+						Description: "Maximum number of Leases allowed for this network (default: default quota)",
+						Default:     DefaultQuotaValue,
 					},
 				},
-				"image_quotas": {
-					Type:        schema.TypeList,
-					Optional:    true,
-					Description: "Image quotas",
-					Elem: &schema.Resource{
-						Schema: map[string]*schema.Schema{
-							"id": {
-								Type:        schema.TypeInt,
-								Required:    true,
-								Description: "Image ID",
-							},
-							"running_vms": {
-								Type:        schema.TypeInt,
-								Optional:    true,
-								Description: "Maximum number of Running VMs allowed for this image (default: default quota)",
-								Default:     -1,
-							},
-						},
+			},
+		},
+		"image": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "Image quotas",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"id": {
+						Type:        schema.TypeInt,
+						Required:    true,
+						Description: "Image ID",
+					},
+					"running_vms": {
+						Type:        schema.TypeInt,
+						Optional:    true,
+						Description: "Maximum number of Running VMs allowed for this image (default: default quota)",
+						Default:     DefaultQuotaValue,
 					},
 				},
-				"vm_quotas": {
-					Type:        schema.TypeList,
-					Optional:    true,
-					Description: "VM quotas",
-					Elem: &schema.Resource{
-						Schema: map[string]*schema.Schema{
-							"cpu": {
-								Type:        schema.TypeFloat,
-								Optional:    true,
-								Description: "Maximum number of CPU allowed (default: default quota)",
-								Default:     -1,
-							},
-							"memory": {
-								Type:        schema.TypeInt,
-								Optional:    true,
-								Description: "Maximum Memory (MB) allowed (default: default quota)",
-								Default:     -1,
-							},
-							"running_cpu": {
-								Type:        schema.TypeFloat,
-								Optional:    true,
-								Description: "Maximum number of 'running' CPUs allowed (default: default quota)",
-								Default:     -1,
-							},
-							"running_memory": {
-								Type:        schema.TypeInt,
-								Optional:    true,
-								Description: "'Running' Memory (MB) allowed (default: default quota)",
-								Default:     -1,
-							},
-							"running_vms": {
-								Type:        schema.TypeInt,
-								Optional:    true,
-								Description: "Maximum number of Running VMs allowed (default: default quota)",
-								Default:     -1,
-							},
-							"system_disk_size": {
-								Type:        schema.TypeInt,
-								Optional:    true,
-								Description: "Maximum System Disk size (MB) allowed (default: default quota)",
-								Default:     -1,
-							},
-							"vms": {
-								Type:        schema.TypeInt,
-								Optional:    true,
-								Description: "Maximum number of VMs allowed (default: default quota)",
-								Default:     -1,
-							},
-						},
+			},
+		},
+		"vm": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "VM quotas",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"cpu": {
+						Type:        schema.TypeFloat,
+						Optional:    true,
+						Description: "Maximum number of CPU allowed (default: default quota)",
+						Default:     DefaultQuotaValue,
+					},
+					"memory": {
+						Type:        schema.TypeInt,
+						Optional:    true,
+						Description: "Maximum Memory (MB) allowed (default: default quota)",
+						Default:     DefaultQuotaValue,
+					},
+					"running_cpu": {
+						Type:        schema.TypeFloat,
+						Optional:    true,
+						Description: "Maximum number of 'running' CPUs allowed (default: default quota)",
+						Default:     DefaultQuotaValue,
+					},
+					"running_memory": {
+						Type:        schema.TypeInt,
+						Optional:    true,
+						Description: "'Running' Memory (MB) allowed (default: default quota)",
+						Default:     DefaultQuotaValue,
+					},
+					"running_vms": {
+						Type:        schema.TypeInt,
+						Optional:    true,
+						Description: "Maximum number of Running VMs allowed (default: default quota)",
+						Default:     DefaultQuotaValue,
+					},
+					"system_disk_size": {
+						Type:        schema.TypeInt,
+						Optional:    true,
+						Description: "Maximum System Disk size (MB) allowed (default: default quota)",
+						Default:     DefaultQuotaValue,
+					},
+					"vms": {
+						Type:        schema.TypeInt,
+						Optional:    true,
+						Description: "Maximum number of VMs allowed (default: default quota)",
+						Default:     DefaultQuotaValue,
 					},
 				},
 			},
@@ -146,16 +140,14 @@ func quotasSchema() *schema.Schema {
 	}
 }
 
-func generateQuotas(d *schema.ResourceData) (string, error) {
-	quotas := d.Get("quotas").(*schema.Set).List()
+func generateQuotas(d *schema.ResourceData, forceDefault bool) (string, error) {
 
 	tpl := dyn.NewTemplate()
 
-	quotasMap := quotas[0].(map[string]interface{})
-	datastore := quotasMap["datastore_quotas"].([]interface{})
-	network := quotasMap["network_quotas"].([]interface{})
-	image := quotasMap["image_quotas"].([]interface{})
-	vm := quotasMap["vm_quotas"].([]interface{})
+	datastore := d.Get("datastore").([]interface{})
+	network := d.Get("network").([]interface{})
+	image := d.Get("image").([]interface{})
+	vm := d.Get("vm").([]interface{})
 
 	for i := 0; i < len(datastore); i++ {
 		datastoreTpl := tpl.AddVector("DATASTORE")
@@ -163,14 +155,11 @@ func generateQuotas(d *schema.ResourceData) (string, error) {
 		datastoreMap := datastore[i].(map[string]interface{})
 
 		datastoreTpl.AddPair("ID", datastoreMap["id"].(int))
-		if datastoreMap["images"].(int) == -1 {
-			if datastoreMap["size"].(int) == -1 {
-				return "", fmt.Errorf("can't build datastore quota, images or size must be defined\n")
-			}
+		if forceDefault {
+			datastoreTpl.AddPair("IMAGES", DefaultQuotaValue)
+			datastoreTpl.AddPair("SIZE", DefaultQuotaValue)
 		} else {
 			datastoreTpl.AddPair("IMAGES", datastoreMap["images"].(int))
-		}
-		if datastoreMap["size"].(int) != -1 {
 			datastoreTpl.AddPair("SIZE", datastoreMap["size"].(int))
 		}
 	}
@@ -182,10 +171,10 @@ func generateQuotas(d *schema.ResourceData) (string, error) {
 
 		networkTpl.AddPair("ID", networkMap["id"].(int))
 
-		if networkMap["leases"].(int) != -1 {
-			networkTpl.AddPair("LEASES", networkMap["leases"].(int))
+		if forceDefault {
+			networkTpl.AddPair("LEASES", DefaultQuotaValue)
 		} else {
-			return "", fmt.Errorf("can't build network quota, leases must be defined\n")
+			networkTpl.AddPair("LEASES", networkMap["leases"].(int))
 		}
 	}
 
@@ -196,10 +185,10 @@ func generateQuotas(d *schema.ResourceData) (string, error) {
 
 		imageTpl.AddPair("ID", imageMap["id"].(int))
 
-		if imageMap["running_vms"].(int) != -1 {
-			imageTpl.AddPair("RVMS", imageMap["running_vms"].(int))
+		if forceDefault {
+			imageTpl.AddPair("RVMS", DefaultQuotaValue)
 		} else {
-			return "", fmt.Errorf("can't build image quota, running_vms must be defined\n")
+			imageTpl.AddPair("RVMS", imageMap["running_vms"].(int))
 		}
 	}
 
@@ -208,25 +197,21 @@ func generateQuotas(d *schema.ResourceData) (string, error) {
 
 		vmTpl := tpl.AddVector("VM")
 
-		if vmMap["cpu"].(float64) != -1.0 {
+		if forceDefault {
+			vmTpl.AddPair("CPU", DefaultQuotaValue)
+			vmTpl.AddPair("MEMORY", DefaultQuotaValue)
+			vmTpl.AddPair("RUNNING_CPU", DefaultQuotaValue)
+			vmTpl.AddPair("RUNNING_MEMORY", DefaultQuotaValue)
+			vmTpl.AddPair("RUNNING_VMS", DefaultQuotaValue)
+			vmTpl.AddPair("SYSTEM_DISK_SIZE", DefaultQuotaValue)
+			vmTpl.AddPair("VMS", DefaultQuotaValue)
+		} else {
 			vmTpl.AddPair("CPU", float32(vmMap["cpu"].(float64)))
-		}
-		if vmMap["memory"].(int) != -1 {
 			vmTpl.AddPair("MEMORY", vmMap["memory"].(int))
-		}
-		if vmMap["running_cpu"].(float64) != -1.0 {
 			vmTpl.AddPair("RUNNING_CPU", float32(vmMap["running_cpu"].(float64)))
-		}
-		if vmMap["running_memory"].(int) != -1 {
 			vmTpl.AddPair("RUNNING_MEMORY", vmMap["running_memory"].(int))
-		}
-		if vmMap["running_vms"].(int) != -1 {
 			vmTpl.AddPair("RUNNING_VMS", vmMap["running_vms"].(int))
-		}
-		if vmMap["system_disk_size"].(int) != -1 {
 			vmTpl.AddPair("SYSTEM_DISK_SIZE", vmMap["system_disk_size"].(int))
-		}
-		if vmMap["vms"].(int) != -1 {
 			vmTpl.AddPair("VMS", vmMap["vms"].(int))
 		}
 	}
@@ -256,6 +241,7 @@ func flattenQuotasMapFromStructs(d *schema.ResourceData, quotas *shared.QuotasLi
 		}
 		q = q | DSFlag
 	}
+
 	// Get network quotas
 	for _, qn := range quotas.Network {
 		n := make(map[string]interface{})
@@ -294,29 +280,22 @@ func flattenQuotasMapFromStructs(d *schema.ResourceData, quotas *shared.QuotasLi
 		q = q | ImgFlag
 	}
 
-	quotasMap := make(map[string]interface{}, 0)
 	for q > 0 {
 		switch {
 		case q&DSFlag > 0:
-			quotasMap["datastore_quotas"] = datastoreQuotas
+			d.Set("datastore", datastoreQuotas)
 			q = q ^ DSFlag
 		case q&NetFlag > 0:
-			quotasMap["network_quotas"] = networkQuotas
+			d.Set("network", networkQuotas)
 			q = q ^ NetFlag
 		case q&VMFlag > 0:
-			quotasMap["vm_quotas"] = vmQuotas
+			d.Set("vm", vmQuotas)
 			q = q ^ VMFlag
 		case q&ImgFlag > 0:
-			quotasMap["image_quotas"] = imageQuotas
+			d.Set("image", imageQuotas)
 			q = q ^ ImgFlag
 		}
 	}
 
-	if len(quotasMap) > 0 {
-		return d.Set("quotas", []interface{}{
-			quotasMap,
-		})
-	} else {
-		return nil
-	}
+	return nil
 }

--- a/opennebula/resource_opennebula_group.go
+++ b/opennebula/resource_opennebula_group.go
@@ -55,7 +55,11 @@ func resourceOpennebulaGroup() *schema.Resource {
 				},
 				Deprecated: "use opennebula_group_admins resource instead.",
 			},
-			"quotas": quotasSchema(),
+			"quotas": func() *schema.Schema {
+				s := oldQuotasSchema()
+				s.Deprecated = "Use opennebula_user_quota resource instead"
+				return s
+			}(),
 			"sunstone": {
 				Type:        schema.TypeSet,
 				Optional:    true,
@@ -209,7 +213,7 @@ func resourceOpennebulaGroupCreate(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	if _, ok := d.GetOk("quotas"); ok {
-		quotasStr, err := generateQuotas(d)
+		quotasStr, err := generateOldQuotas(d)
 		if err != nil {
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,
@@ -402,7 +406,7 @@ func resourceOpennebulaGroupRead(ctx context.Context, d *schema.ResourceData, me
 		return diags
 	}
 	if _, ok := d.GetOk("quotas"); ok {
-		err = flattenQuotasMapFromStructs(d, &group.QuotasList)
+		err = flattenOldQuotasMapFromStructs(d, &group.QuotasList)
 		if err != nil {
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,
@@ -532,7 +536,7 @@ func resourceOpennebulaGroupUpdate(ctx context.Context, d *schema.ResourceData, 
 
 	if d.HasChange("quotas") {
 		if _, ok := d.GetOk("quotas"); ok {
-			quotasStr, err := generateQuotas(d)
+			quotasStr, err := generateOldQuotas(d)
 			if err != nil {
 				diags = append(diags, diag.Diagnostic{
 					Severity: diag.Error,

--- a/opennebula/resource_opennebula_group_quotas.go
+++ b/opennebula/resource_opennebula_group_quotas.go
@@ -1,0 +1,193 @@
+package opennebula
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceOpennebulaGroupQuotas() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceOpennebulaGroupQuotasCreate,
+		ReadContext:   resourceOpennebulaGroupQuotasRead,
+		UpdateContext: resourceOpennebulaGroupQuotasUpdate,
+		DeleteContext: resourceOpennebulaGroupQuotasDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: mergeSchemas(map[string]*schema.Schema{
+			"group_id": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				ForceNew:    true,
+				Description: "ID of the group to apply the quota",
+			},
+		},
+			quotasMapSchema()),
+	}
+}
+
+func resourceOpennebulaGroupQuotasCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Configuration)
+	controller := config.Controller
+
+	var diags diag.Diagnostics
+
+	groupID := d.Get("group_id").(int)
+	gc := controller.Group(groupID)
+
+	quotasStr, err := generateQuotas(d, false)
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Failed to generate quotas description",
+			Detail:   fmt.Sprintf("group (ID: %s) quotas: %s", d.Id(), err),
+		})
+		return diags
+	}
+	log.Printf("[DEBUG] create quotasStr: %s", quotasStr)
+	err = gc.Quota(quotasStr)
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Failed to apply quotas",
+			Detail:   fmt.Sprintf("group (ID: %s) quotas: %s", d.Id(), err),
+		})
+		return diags
+	}
+
+	d.SetId(fmt.Sprint(groupID))
+
+	return resourceOpennebulaGroupQuotasRead(ctx, d, meta)
+}
+
+func resourceOpennebulaGroupQuotasRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+
+	config := meta.(*Configuration)
+	controller := config.Controller
+
+	var diags diag.Diagnostics
+
+	groupID, err := strconv.ParseInt(d.Id(), 10, 0)
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Failed to parse the group quotas ID",
+			Detail:   err.Error(),
+		})
+		return diags
+	}
+	d.Set("group_id", groupID)
+
+	groupInfos, err := controller.Group(int(groupID)).Info(false)
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Failed to retrieve informations",
+			Detail:   fmt.Sprintf("group (ID: %s) quotas: %s", d.Id(), err),
+		})
+		return diags
+
+	}
+
+	err = flattenQuotasMapFromStructs(d, &groupInfos.QuotasList)
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Failed to flatten quotas",
+			Detail:   fmt.Sprintf("group (ID: %s) quotas: %s", d.Id(), err),
+		})
+		return diags
+	}
+
+	return diags
+}
+
+func resourceOpennebulaGroupQuotasUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+
+	config := meta.(*Configuration)
+	controller := config.Controller
+
+	var diags diag.Diagnostics
+
+	groupID, err := strconv.ParseInt(d.Id(), 10, 0)
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Failed to parse the group quotas ID",
+			Detail:   err.Error(),
+		})
+		return diags
+	}
+
+	if d.HasChange("datastore") || d.HasChange("network") || d.HasChange("image") || d.HasChange("vm") {
+		quotasStr, err := generateQuotas(d, false)
+		if err != nil {
+			if err != nil {
+				diags = append(diags, diag.Diagnostic{
+					Severity: diag.Error,
+					Summary:  "Failed to generate quotas description",
+					Detail:   fmt.Sprintf("group (ID: %s) quotas: %s", d.Id(), err),
+				})
+				return diags
+			}
+		}
+		err = controller.Group(int(groupID)).Quota(quotasStr)
+		if err != nil {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  "Failed apply quotas",
+				Detail:   fmt.Sprintf("group (ID: %s) quotas: %s", d.Id(), err),
+			})
+			return diags
+		}
+
+	}
+
+	return resourceOpennebulaGroupQuotasRead(ctx, d, meta)
+}
+
+func resourceOpennebulaGroupQuotasDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+
+	config := meta.(*Configuration)
+	controller := config.Controller
+
+	var diags diag.Diagnostics
+
+	groupID, err := strconv.ParseInt(d.Id(), 10, 0)
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Failed to parse the group quotas ID",
+			Detail:   err.Error(),
+		})
+		return diags
+	}
+
+	quotasStr, err := generateQuotas(d, true)
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Failed to generate quotas description",
+			Detail:   fmt.Sprintf("group (ID: %s) quotas: %s", d.Id(), err),
+		})
+		return diags
+	}
+
+	err = controller.Group(int(groupID)).Quota(quotasStr)
+
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Failed apply quotas",
+			Detail:   fmt.Sprintf("group (ID: %s) quotas: %s", d.Id(), err),
+		})
+		return diags
+	}
+
+	return nil
+}

--- a/opennebula/resource_opennebula_group_test.go
+++ b/opennebula/resource_opennebula_group_test.go
@@ -39,15 +39,13 @@ func TestAccGroup(t *testing.T) {
 						"elements.testkey1": "testvalue1",
 						"elements.testkey2": "testvalue2",
 					}),
-					resource.TestCheckResourceAttr("opennebula_group_quotas.quotas", "datastore.#", "1"),
-					resource.TestCheckResourceAttr("opennebula_group_quotas.quotas", "datastore.0.id", "1"),
-					resource.TestCheckResourceAttr("opennebula_group_quotas.quotas", "datastore.0.images", "3"),
-					resource.TestCheckResourceAttr("opennebula_group_quotas.quotas", "datastore.0.size", "100"),
-					resource.TestCheckResourceAttr("opennebula_group_quotas.quotas", "image.#", "0"),
-					resource.TestCheckResourceAttr("opennebula_group_quotas.quotas", "network.#", "0"),
-					resource.TestCheckResourceAttr("opennebula_group_quotas.quotas", "vm.#", "1"),
-					resource.TestCheckResourceAttr("opennebula_group_quotas.quotas", "vm.0.cpu", "4"),
-					resource.TestCheckResourceAttr("opennebula_group_quotas.quotas", "vm.0.memory", "8192"),
+					resource.TestCheckResourceAttr("opennebula_group_quotas.datastore", "datastore.#", "1"),
+					resource.TestCheckResourceAttr("opennebula_group_quotas.datastore", "datastore.0.id", "1"),
+					resource.TestCheckResourceAttr("opennebula_group_quotas.datastore", "datastore.0.images", "3"),
+					resource.TestCheckResourceAttr("opennebula_group_quotas.datastore", "datastore.0.size", "100"),
+					resource.TestCheckResourceAttr("opennebula_group_quotas.vm", "vm.#", "1"),
+					resource.TestCheckResourceAttr("opennebula_group_quotas.vm", "vm.0.cpu", "4"),
+					resource.TestCheckResourceAttr("opennebula_group_quotas.vm", "vm.0.memory", "8192"),
 				),
 			},
 			{
@@ -73,15 +71,13 @@ func TestAccGroup(t *testing.T) {
 						"elements.testkey2": "testvalue2",
 						"elements.testkey3": "testvalue3",
 					}),
-					resource.TestCheckResourceAttr("opennebula_group_quotas.quotas", "datastore.#", "1"),
-					resource.TestCheckResourceAttr("opennebula_group_quotas.quotas", "datastore.0.id", "1"),
-					resource.TestCheckResourceAttr("opennebula_group_quotas.quotas", "datastore.0.images", "4"),
-					resource.TestCheckResourceAttr("opennebula_group_quotas.quotas", "datastore.0.size", "100"),
-					resource.TestCheckResourceAttr("opennebula_group_quotas.quotas", "image.#", "0"),
-					resource.TestCheckResourceAttr("opennebula_group_quotas.quotas", "network.#", "0"),
-					resource.TestCheckResourceAttr("opennebula_group_quotas.quotas", "vm.#", "1"),
-					resource.TestCheckResourceAttr("opennebula_group_quotas.quotas", "vm.0.cpu", "4"),
-					resource.TestCheckResourceAttr("opennebula_group_quotas.quotas", "vm.0.memory", "8192"),
+					resource.TestCheckResourceAttr("opennebula_group_quotas.datastore", "datastore.#", "1"),
+					resource.TestCheckResourceAttr("opennebula_group_quotas.datastore", "datastore.0.id", "1"),
+					resource.TestCheckResourceAttr("opennebula_group_quotas.datastore", "datastore.0.images", "4"),
+					resource.TestCheckResourceAttr("opennebula_group_quotas.datastore", "datastore.0.size", "100"),
+					resource.TestCheckResourceAttr("opennebula_group_quotas.vm", "vm.#", "1"),
+					resource.TestCheckResourceAttr("opennebula_group_quotas.vm", "vm.0.cpu", "4"),
+					resource.TestCheckResourceAttr("opennebula_group_quotas.vm", "vm.0.memory", "8192"),
 				),
 			},
 			{
@@ -222,13 +218,17 @@ resource "opennebula_group" "group" {
 	  }
 }
 
-resource "opennebula_group_quotas" "quotas" {
+resource "opennebula_group_quotas" "datastore" {
 	group_id = opennebula_group.group.id
 	datastore {
 		id = 1
 		images = 3
 		size = 100
 	}
+}
+
+resource "opennebula_group_quotas" "vm" {
+	group_id = opennebula_group.group.id
 	vm {
 		cpu = 4
 		memory = 8192
@@ -269,13 +269,17 @@ resource "opennebula_group" "group" {
 	  }
 }
 
-resource "opennebula_group_quotas" "quotas" {
+resource "opennebula_group_quotas" "datastore" {
 	group_id = opennebula_group.group.id
 	datastore {
 		id = 1
 		images = 4
 		size = 100
 	}
+}
+
+resource "opennebula_group_quotas" "vm" {
+	group_id = opennebula_group.group.id
 	vm {
 		cpu = 4
 		memory = 8192
@@ -313,13 +317,17 @@ resource "opennebula_group" "group" {
 	  }
 }
 
-resource "opennebula_group_quotas" "quotas" {
+resource "opennebula_group_quotas" "datastore" {
 	group_id = opennebula_group.group.id
 	datastore {
 		id = 1
 		images = 4
 		size = 100
 	}
+}
+
+resource "opennebula_group_quotas" "vm" {
+	group_id = opennebula_group.group.id
 	vm {
 		cpu = 4
 		memory = 8192
@@ -373,13 +381,17 @@ resource "opennebula_group" "group" {
 	  }
 }
 
-resource "opennebula_group_quotas" "quotas" {
+resource "opennebula_group_quotas" "datastore" {
 	group_id = opennebula_group.group.id
 	datastore {
 		id = 1
 		images = 4
 		size = 100
 	}
+}
+
+resource "opennebula_group_quotas" "vm" {
+	group_id = opennebula_group.group.id
 	vm {
 		cpu = 4
 		memory = 8192

--- a/opennebula/resource_opennebula_group_test.go
+++ b/opennebula/resource_opennebula_group_test.go
@@ -19,18 +19,6 @@ func TestAccGroup(t *testing.T) {
 				Config: testAccGroupConfigBasic,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("opennebula_group.group", "name", "iamgroup"),
-					resource.TestCheckResourceAttr("opennebula_group.group", "quotas.#", "1"),
-					resource.TestCheckTypeSetElemNestedAttrs("opennebula_group.group", "quotas.*", map[string]string{
-						"datastore_quotas.#":        "1",
-						"datastore_quotas.0.id":     "1",
-						"datastore_quotas.0.images": "3",
-						"datastore_quotas.0.size":   "100",
-						"image_quotas.#":            "0",
-						"network_quotas.#":          "0",
-						"vm_quotas.#":               "1",
-						"vm_quotas.0.cpu":           "4",
-						"vm_quotas.0.memory":        "8192",
-					}),
 					resource.TestCheckResourceAttr("opennebula_group.group", "sunstone.0.%", "4"),
 					resource.TestCheckTypeSetElemNestedAttrs("opennebula_group.group", "sunstone.*", map[string]string{
 						"default_view":             "cloud",
@@ -51,24 +39,21 @@ func TestAccGroup(t *testing.T) {
 						"elements.testkey1": "testvalue1",
 						"elements.testkey2": "testvalue2",
 					}),
+					resource.TestCheckResourceAttr("opennebula_group_quotas.quotas", "datastore.#", "1"),
+					resource.TestCheckResourceAttr("opennebula_group_quotas.quotas", "datastore.0.id", "1"),
+					resource.TestCheckResourceAttr("opennebula_group_quotas.quotas", "datastore.0.images", "3"),
+					resource.TestCheckResourceAttr("opennebula_group_quotas.quotas", "datastore.0.size", "100"),
+					resource.TestCheckResourceAttr("opennebula_group_quotas.quotas", "image.#", "0"),
+					resource.TestCheckResourceAttr("opennebula_group_quotas.quotas", "network.#", "0"),
+					resource.TestCheckResourceAttr("opennebula_group_quotas.quotas", "vm.#", "1"),
+					resource.TestCheckResourceAttr("opennebula_group_quotas.quotas", "vm.0.cpu", "4"),
+					resource.TestCheckResourceAttr("opennebula_group_quotas.quotas", "vm.0.memory", "8192"),
 				),
 			},
 			{
 				Config: testAccGroupConfigUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("opennebula_group.group", "name", "iamgroup"),
-					resource.TestCheckResourceAttr("opennebula_group.group", "quotas.#", "1"),
-					resource.TestCheckTypeSetElemNestedAttrs("opennebula_group.group", "quotas.*", map[string]string{
-						"datastore_quotas.#":        "1",
-						"datastore_quotas.0.id":     "1",
-						"datastore_quotas.0.images": "4",
-						"datastore_quotas.0.size":   "100",
-						"image_quotas.#":            "0",
-						"network_quotas.#":          "0",
-						"vm_quotas.#":               "1",
-						"vm_quotas.0.cpu":           "4",
-						"vm_quotas.0.memory":        "8192",
-					}),
 					resource.TestCheckResourceAttr("opennebula_group.group", "sunstone.0.%", "4"),
 					resource.TestCheckTypeSetElemNestedAttrs("opennebula_group.group", "sunstone.*", map[string]string{
 						"default_view":             "cloud",
@@ -88,6 +73,15 @@ func TestAccGroup(t *testing.T) {
 						"elements.testkey2": "testvalue2",
 						"elements.testkey3": "testvalue3",
 					}),
+					resource.TestCheckResourceAttr("opennebula_group_quotas.quotas", "datastore.#", "1"),
+					resource.TestCheckResourceAttr("opennebula_group_quotas.quotas", "datastore.0.id", "1"),
+					resource.TestCheckResourceAttr("opennebula_group_quotas.quotas", "datastore.0.images", "4"),
+					resource.TestCheckResourceAttr("opennebula_group_quotas.quotas", "datastore.0.size", "100"),
+					resource.TestCheckResourceAttr("opennebula_group_quotas.quotas", "image.#", "0"),
+					resource.TestCheckResourceAttr("opennebula_group_quotas.quotas", "network.#", "0"),
+					resource.TestCheckResourceAttr("opennebula_group_quotas.quotas", "vm.#", "1"),
+					resource.TestCheckResourceAttr("opennebula_group_quotas.quotas", "vm.0.cpu", "4"),
+					resource.TestCheckResourceAttr("opennebula_group_quotas.quotas", "vm.0.memory", "8192"),
 				),
 			},
 			{
@@ -208,17 +202,6 @@ resource "opennebula_group" "group" {
 	  api_list_order = "ASC"
 	}
 
-    quotas {
-        datastore_quotas {
-            id = 1
-            images = 3
-            size = 100
-        }
-        vm_quotas {
-            cpu = 4
-            memory = 8192
-        }
-    }
 	tags = {
 		testkey1 = "testvalue1"
 		testkey2 = "testvalue2"
@@ -230,6 +213,25 @@ resource "opennebula_group" "group" {
 			testkey1 = "testvalue1"
 			testkey2 = "testvalue2"
 		}
+	}
+
+	lifecycle {
+		ignore_changes = [
+		  "quotas"
+		]
+	  }
+}
+
+resource "opennebula_group_quotas" "quotas" {
+	group_id = opennebula_group.group.id
+	datastore {
+		id = 1
+		images = 3
+		size = 100
+	}
+	vm {
+		cpu = 4
+		memory = 8192
 	}
 }
 `
@@ -247,17 +249,6 @@ resource "opennebula_group" "group" {
 		api_list_order = "DESC"
 	}
 
-    quotas {
-        datastore_quotas {
-            id = 1
-            images = 4
-            size = 100
-        }
-        vm_quotas {
-            cpu = 4
-            memory = 8192
-        }
-    }
 	tags = {
 		testkey2 = "testvalue2"
 		testkey3 = "testvalue3"
@@ -269,6 +260,25 @@ resource "opennebula_group" "group" {
 			testkey2 = "testvalue2"
 			testkey3 = "testvalue3"
 		}
+	}
+
+	lifecycle {
+		ignore_changes = [
+		  "quotas"
+		]
+	  }
+}
+
+resource "opennebula_group_quotas" "quotas" {
+	group_id = opennebula_group.group.id
+	datastore {
+		id = 1
+		images = 4
+		size = 100
+	}
+	vm {
+		cpu = 4
+		memory = 8192
 	}
 }
 `
@@ -282,17 +292,7 @@ resource "opennebula_group" "group" {
 		group_admin_views = "cloud"
 		views = "cloud"
 	}
-    quotas {
-        datastore_quotas {
-            id = 1
-            images = 4
-            size = 100
-        }
-        vm_quotas {
-            cpu = 4
-            memory = 8192
-        }
-    }
+
 	tags = {
 		testkey2 = "testvalue2"
 		testkey3 = "testvalue3"
@@ -304,6 +304,25 @@ resource "opennebula_group" "group" {
 			testkey2 = "testvalue2"
 			testkey3 = "testvalue3"
 		}
+	}
+
+	lifecycle {
+		ignore_changes = [
+		  "quotas"
+		]
+	  }
+}
+
+resource "opennebula_group_quotas" "quotas" {
+	group_id = opennebula_group.group.id
+	datastore {
+		id = 1
+		images = 4
+		size = 100
+	}
+	vm {
+		cpu = 4
+		memory = 8192
 	}
 }
 `
@@ -346,17 +365,25 @@ resource "opennebula_group" "group" {
 		group_admin_views = "cloud"
 		views = "cloud"
 	}
-    quotas {
-        datastore_quotas {
-            id = 1
-            images = 4
-            size = 100
-        }
-        vm_quotas {
-            cpu = 4
-            memory = 8192
-        }
-    }
+
+	lifecycle {
+		ignore_changes = [
+		  "quotas"
+		]
+	  }
+}
+
+resource "opennebula_group_quotas" "quotas" {
+	group_id = opennebula_group.group.id
+	datastore {
+		id = 1
+		images = 4
+		size = 100
+	}
+	vm {
+		cpu = 4
+		memory = 8192
+	}
 }
 
 resource "opennebula_group" "group2" {

--- a/opennebula/resource_opennebula_user.go
+++ b/opennebula/resource_opennebula_user.go
@@ -75,7 +75,11 @@ func resourceOpennebulaUser() *schema.Resource {
 					Type: schema.TypeInt,
 				},
 			},
-			"quotas":           quotasSchema(),
+			"quotas": func() *schema.Schema {
+				s := oldQuotasSchema()
+				s.Deprecated = "Use opennebula_group_quota resource instead"
+				return s
+			}(),
 			"tags":             tagsSchema(),
 			"default_tags":     defaultTagsSchemaComputed(),
 			"tags_all":         tagsSchemaComputed(),
@@ -142,7 +146,7 @@ func resourceOpennebulaUserCreate(ctx context.Context, d *schema.ResourceData, m
 	uc := controller.User(userID)
 
 	if _, ok := d.GetOk("quotas"); ok {
-		quotasStr, err := generateQuotas(d)
+		quotasStr, err := generateOldQuotas(d)
 		if err != nil {
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,
@@ -270,7 +274,7 @@ func resourceOpennebulaUserRead(ctx context.Context, d *schema.ResourceData, met
 		return diags
 	}
 
-	err = flattenQuotasMapFromStructs(d, &user.QuotasList)
+	err = flattenOldQuotasMapFromStructs(d, &user.QuotasList)
 	if err != nil {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
@@ -440,7 +444,7 @@ func resourceOpennebulaUserUpdate(ctx context.Context, d *schema.ResourceData, m
 
 	if d.HasChange("quotas") {
 		if _, ok := d.GetOk("quotas"); ok {
-			quotasStr, err := generateQuotas(d)
+			quotasStr, err := generateOldQuotas(d)
 			if err != nil {
 				if err != nil {
 					diags = append(diags, diag.Diagnostic{

--- a/opennebula/resource_opennebula_user_quotas.go
+++ b/opennebula/resource_opennebula_user_quotas.go
@@ -1,0 +1,194 @@
+package opennebula
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceOpennebulaUserQuotas() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceOpennebulaUserQuotasCreate,
+		ReadContext:   resourceOpennebulaUserQuotasRead,
+		UpdateContext: resourceOpennebulaUserQuotasUpdate,
+		DeleteContext: resourceOpennebulaUserQuotasDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: mergeSchemas(map[string]*schema.Schema{
+			"user_id": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				ForceNew:    true,
+				Description: "ID of the user to apply the quota",
+			},
+		},
+			quotasMapSchema()),
+	}
+}
+
+func resourceOpennebulaUserQuotasCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Configuration)
+	controller := config.Controller
+
+	var diags diag.Diagnostics
+
+	userID := d.Get("user_id").(int)
+	uc := controller.User(userID)
+
+	quotasStr, err := generateQuotas(d, false)
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Failed to generate quotas description",
+			Detail:   fmt.Sprintf("user (ID: %s) quotas: %s", d.Id(), err),
+		})
+		return diags
+	}
+	log.Printf("[DEBUG] create quotasStr: %s", quotasStr)
+	err = uc.Quota(quotasStr)
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Failed to apply quotas",
+			Detail:   fmt.Sprintf("user (ID: %s) quotas: %s", d.Id(), err),
+		})
+		return diags
+	}
+
+	d.SetId(fmt.Sprint(userID))
+
+	return resourceOpennebulaUserQuotasRead(ctx, d, meta)
+}
+
+func resourceOpennebulaUserQuotasRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+
+	config := meta.(*Configuration)
+	controller := config.Controller
+
+	var diags diag.Diagnostics
+
+	userID, err := strconv.ParseInt(d.Id(), 10, 0)
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Failed to parse the user quotas ID",
+			Detail:   err.Error(),
+		})
+		return diags
+	}
+	d.Set("user_id", userID)
+
+	userInfos, err := controller.User(int(userID)).Info(false)
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Failed to retrieve informations",
+			Detail:   fmt.Sprintf("user (ID: %s) quotas: %s", d.Id(), err),
+		})
+		return diags
+
+	}
+
+	err = flattenQuotasMapFromStructs(d, &userInfos.QuotasList)
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Failed to flatten quotas",
+			Detail:   fmt.Sprintf("user (ID: %s) quotas: %s", d.Id(), err),
+		})
+		return diags
+	}
+
+	return diags
+}
+
+func resourceOpennebulaUserQuotasUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+
+	config := meta.(*Configuration)
+	controller := config.Controller
+
+	var diags diag.Diagnostics
+
+	userID, err := strconv.ParseInt(d.Id(), 10, 0)
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Failed to parse the user quotas ID",
+			Detail:   err.Error(),
+		})
+		return diags
+	}
+
+	if d.HasChange("datastore") || d.HasChange("network") || d.HasChange("image") || d.HasChange("vm") {
+		quotasStr, err := generateQuotas(d, false)
+		if err != nil {
+			if err != nil {
+				diags = append(diags, diag.Diagnostic{
+					Severity: diag.Error,
+					Summary:  "Failed to generate quotas description",
+					Detail:   fmt.Sprintf("user (ID: %s) quotas: %s", d.Id(), err),
+				})
+				return diags
+			}
+		}
+		err = controller.User(int(userID)).Quota(quotasStr)
+		if err != nil {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  "Failed apply quotas",
+				Detail:   fmt.Sprintf("user (ID: %s) quotas: %s", d.Id(), err),
+			})
+			return diags
+		}
+
+	}
+
+	return resourceOpennebulaUserQuotasRead(ctx, d, meta)
+}
+
+func resourceOpennebulaUserQuotasDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+
+	config := meta.(*Configuration)
+	controller := config.Controller
+
+	var diags diag.Diagnostics
+
+	userID, err := strconv.ParseInt(d.Id(), 10, 0)
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Failed to parse the user quotas ID",
+			Detail:   err.Error(),
+		})
+		return diags
+	}
+
+	quotasStr, err := generateQuotas(d, true)
+	if err != nil {
+		if err != nil {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  "Failed to generate quotas description",
+				Detail:   fmt.Sprintf("user (ID: %s) quotas: %s", d.Id(), err),
+			})
+			return diags
+		}
+	}
+
+	err = controller.User(int(userID)).Quota(quotasStr)
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Failed apply quotas",
+			Detail:   fmt.Sprintf("user (ID: %s) quotas: %s", d.Id(), err),
+		})
+		return diags
+	}
+
+	return nil
+}

--- a/opennebula/resource_opennebula_user_test.go
+++ b/opennebula/resource_opennebula_user_test.go
@@ -22,18 +22,15 @@ func TestAccUser(t *testing.T) {
 					resource.TestCheckResourceAttr("opennebula_user.user", "password", "p@ssw0rd"),
 					resource.TestCheckResourceAttr("opennebula_user.user", "auth_driver", "core"),
 					resource.TestCheckResourceAttr("opennebula_user.user", "ssh_public_key", "xxx"),
-					resource.TestCheckResourceAttr("opennebula_user.user", "quotas.#", "1"),
-					resource.TestCheckTypeSetElemNestedAttrs("opennebula_user.user", "quotas.*", map[string]string{
-						"datastore_quotas.#":        "1",
-						"datastore_quotas.0.id":     "1",
-						"datastore_quotas.0.images": "3",
-						"datastore_quotas.0.size":   "100",
-						"image_quotas.#":            "0",
-						"network_quotas.#":          "0",
-						"vm_quotas.#":               "1",
-						"vm_quotas.0.cpu":           "4",
-						"vm_quotas.0.memory":        "8192",
-					}),
+					resource.TestCheckResourceAttr("opennebula_user_quotas.quotas", "datastore.#", "1"),
+					resource.TestCheckResourceAttr("opennebula_user_quotas.quotas", "datastore.0.id", "1"),
+					resource.TestCheckResourceAttr("opennebula_user_quotas.quotas", "datastore.0.images", "3"),
+					resource.TestCheckResourceAttr("opennebula_user_quotas.quotas", "datastore.0.size", "100"),
+					resource.TestCheckResourceAttr("opennebula_user_quotas.quotas", "image.#", "0"),
+					resource.TestCheckResourceAttr("opennebula_user_quotas.quotas", "network.#", "0"),
+					resource.TestCheckResourceAttr("opennebula_user_quotas.quotas", "vm.#", "1"),
+					resource.TestCheckResourceAttr("opennebula_user_quotas.quotas", "vm.0.cpu", "4"),
+					resource.TestCheckResourceAttr("opennebula_user_quotas.quotas", "vm.0.memory", "8192"),
 					resource.TestCheckResourceAttr("opennebula_user.user", "tags.testkey1", "testvalue1"),
 					resource.TestCheckResourceAttr("opennebula_user.user", "tags.testkey2", "testvalue2"),
 				),
@@ -45,18 +42,15 @@ func TestAccUser(t *testing.T) {
 					resource.TestCheckResourceAttr("opennebula_user.user", "password", "p@ssw0rd2"),
 					resource.TestCheckResourceAttr("opennebula_user.user", "auth_driver", "core"),
 					resource.TestCheckResourceAttr("opennebula_user.user", "ssh_public_key", "xxx"),
-					resource.TestCheckResourceAttr("opennebula_user.user", "quotas.#", "1"),
-					resource.TestCheckTypeSetElemNestedAttrs("opennebula_user.user", "quotas.*", map[string]string{
-						"datastore_quotas.#":        "1",
-						"datastore_quotas.0.id":     "1",
-						"datastore_quotas.0.images": "4",
-						"datastore_quotas.0.size":   "100",
-						"image_quotas.#":            "0",
-						"network_quotas.#":          "0",
-						"vm_quotas.#":               "1",
-						"vm_quotas.0.cpu":           "4",
-						"vm_quotas.0.memory":        "8192",
-					}),
+					resource.TestCheckResourceAttr("opennebula_user_quotas.quotas", "datastore.#", "1"),
+					resource.TestCheckResourceAttr("opennebula_user_quotas.quotas", "datastore.0.id", "1"),
+					resource.TestCheckResourceAttr("opennebula_user_quotas.quotas", "datastore.0.images", "4"),
+					resource.TestCheckResourceAttr("opennebula_user_quotas.quotas", "datastore.0.size", "100"),
+					resource.TestCheckResourceAttr("opennebula_user_quotas.quotas", "image.#", "0"),
+					resource.TestCheckResourceAttr("opennebula_user_quotas.quotas", "network.#", "0"),
+					resource.TestCheckResourceAttr("opennebula_user_quotas.quotas", "vm.#", "1"),
+					resource.TestCheckResourceAttr("opennebula_user_quotas.quotas", "vm.0.cpu", "4"),
+					resource.TestCheckResourceAttr("opennebula_user_quotas.quotas", "vm.0.memory", "8192"),
 					resource.TestCheckResourceAttr("opennebula_user.user", "tags.testkey2", "testvalue2"),
 					resource.TestCheckResourceAttr("opennebula_user.user", "tags.testkey3", "testvalue3"),
 				),
@@ -90,20 +84,29 @@ resource "opennebula_user" "user" {
   password = "p@ssw0rd"
   auth_driver = "core"
   ssh_public_key = "xxx"
-  quotas {
-      datastore_quotas {
-          id = 1
-          images = 3
-          size = 100
-      }
-      vm_quotas {
-          cpu = 4
-          memory = 8192
-      }
-  }
+
   tags = {
 	testkey1 = "testvalue1"
 	testkey2 = "testvalue2"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      "quotas"
+    ]
+  }
+}
+
+resource "opennebula_user_quotas" "quotas" {
+  user_id = opennebula_user.user.id
+  datastore {
+    id = 1
+    images = 3
+    size = 100
+  }
+  vm {
+    cpu = 4
+    memory = 8192
   }
 }
 `
@@ -114,20 +117,29 @@ resource "opennebula_user" "user" {
   password = "p@ssw0rd2"
   auth_driver = "core"
   ssh_public_key = "xxx"
-  quotas {
-      datastore_quotas {
-          id = 1
-          images = 4
-          size = 100
-      }
-      vm_quotas {
-          cpu = 4
-          memory = 8192
-      }
-  }
+
   tags = {
 	testkey2 = "testvalue2"
 	testkey3 = "testvalue3"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      "quotas"
+    ]
+  }
+}
+
+resource "opennebula_user_quotas" "quotas" {
+  user_id = opennebula_user.user.id
+  datastore {
+    id = 1
+    images = 4
+    size = 100
+  }
+  vm {
+    cpu = 4
+    memory = 8192
   }
 }
 `

--- a/opennebula/resource_opennebula_user_test.go
+++ b/opennebula/resource_opennebula_user_test.go
@@ -22,15 +22,13 @@ func TestAccUser(t *testing.T) {
 					resource.TestCheckResourceAttr("opennebula_user.user", "password", "p@ssw0rd"),
 					resource.TestCheckResourceAttr("opennebula_user.user", "auth_driver", "core"),
 					resource.TestCheckResourceAttr("opennebula_user.user", "ssh_public_key", "xxx"),
-					resource.TestCheckResourceAttr("opennebula_user_quotas.quotas", "datastore.#", "1"),
-					resource.TestCheckResourceAttr("opennebula_user_quotas.quotas", "datastore.0.id", "1"),
-					resource.TestCheckResourceAttr("opennebula_user_quotas.quotas", "datastore.0.images", "3"),
-					resource.TestCheckResourceAttr("opennebula_user_quotas.quotas", "datastore.0.size", "100"),
-					resource.TestCheckResourceAttr("opennebula_user_quotas.quotas", "image.#", "0"),
-					resource.TestCheckResourceAttr("opennebula_user_quotas.quotas", "network.#", "0"),
-					resource.TestCheckResourceAttr("opennebula_user_quotas.quotas", "vm.#", "1"),
-					resource.TestCheckResourceAttr("opennebula_user_quotas.quotas", "vm.0.cpu", "4"),
-					resource.TestCheckResourceAttr("opennebula_user_quotas.quotas", "vm.0.memory", "8192"),
+					resource.TestCheckResourceAttr("opennebula_user_quotas.datastore", "datastore.#", "1"),
+					resource.TestCheckResourceAttr("opennebula_user_quotas.datastore", "datastore.0.id", "1"),
+					resource.TestCheckResourceAttr("opennebula_user_quotas.datastore", "datastore.0.images", "3"),
+					resource.TestCheckResourceAttr("opennebula_user_quotas.datastore", "datastore.0.size", "100"),
+					resource.TestCheckResourceAttr("opennebula_user_quotas.vm", "vm.#", "1"),
+					resource.TestCheckResourceAttr("opennebula_user_quotas.vm", "vm.0.cpu", "4"),
+					resource.TestCheckResourceAttr("opennebula_user_quotas.vm", "vm.0.memory", "8192"),
 					resource.TestCheckResourceAttr("opennebula_user.user", "tags.testkey1", "testvalue1"),
 					resource.TestCheckResourceAttr("opennebula_user.user", "tags.testkey2", "testvalue2"),
 				),
@@ -42,15 +40,13 @@ func TestAccUser(t *testing.T) {
 					resource.TestCheckResourceAttr("opennebula_user.user", "password", "p@ssw0rd2"),
 					resource.TestCheckResourceAttr("opennebula_user.user", "auth_driver", "core"),
 					resource.TestCheckResourceAttr("opennebula_user.user", "ssh_public_key", "xxx"),
-					resource.TestCheckResourceAttr("opennebula_user_quotas.quotas", "datastore.#", "1"),
-					resource.TestCheckResourceAttr("opennebula_user_quotas.quotas", "datastore.0.id", "1"),
-					resource.TestCheckResourceAttr("opennebula_user_quotas.quotas", "datastore.0.images", "4"),
-					resource.TestCheckResourceAttr("opennebula_user_quotas.quotas", "datastore.0.size", "100"),
-					resource.TestCheckResourceAttr("opennebula_user_quotas.quotas", "image.#", "0"),
-					resource.TestCheckResourceAttr("opennebula_user_quotas.quotas", "network.#", "0"),
-					resource.TestCheckResourceAttr("opennebula_user_quotas.quotas", "vm.#", "1"),
-					resource.TestCheckResourceAttr("opennebula_user_quotas.quotas", "vm.0.cpu", "4"),
-					resource.TestCheckResourceAttr("opennebula_user_quotas.quotas", "vm.0.memory", "8192"),
+					resource.TestCheckResourceAttr("opennebula_user_quotas.datastore", "datastore.#", "1"),
+					resource.TestCheckResourceAttr("opennebula_user_quotas.datastore", "datastore.0.id", "1"),
+					resource.TestCheckResourceAttr("opennebula_user_quotas.datastore", "datastore.0.images", "4"),
+					resource.TestCheckResourceAttr("opennebula_user_quotas.datastore", "datastore.0.size", "100"),
+					resource.TestCheckResourceAttr("opennebula_user_quotas.vm", "vm.#", "1"),
+					resource.TestCheckResourceAttr("opennebula_user_quotas.vm", "vm.0.cpu", "4"),
+					resource.TestCheckResourceAttr("opennebula_user_quotas.vm", "vm.0.memory", "8192"),
 					resource.TestCheckResourceAttr("opennebula_user.user", "tags.testkey2", "testvalue2"),
 					resource.TestCheckResourceAttr("opennebula_user.user", "tags.testkey3", "testvalue3"),
 				),
@@ -97,18 +93,22 @@ resource "opennebula_user" "user" {
   }
 }
 
-resource "opennebula_user_quotas" "quotas" {
+resource "opennebula_user_quotas" "datastore" {
   user_id = opennebula_user.user.id
   datastore {
     id = 1
     images = 3
     size = 100
   }
-  vm {
-    cpu = 4
-    memory = 8192
-  }
 }
+
+resource "opennebula_user_quotas" "vm" {
+	user_id = opennebula_user.user.id
+	vm {
+	  cpu = 4
+	  memory = 8192
+	}
+  }
 `
 
 var testAccUserConfigUpdate = `
@@ -130,16 +130,20 @@ resource "opennebula_user" "user" {
   }
 }
 
-resource "opennebula_user_quotas" "quotas" {
+resource "opennebula_user_quotas" "datastore" {
   user_id = opennebula_user.user.id
   datastore {
     id = 1
     images = 4
     size = 100
   }
-  vm {
-    cpu = 4
-    memory = 8192
-  }
 }
+
+resource "opennebula_user_quotas" "vm" {
+	user_id = opennebula_user.user.id
+	vm {
+	  cpu = 4
+	  memory = 8192
+	}
+  }
 `

--- a/website/docs/r/group.html.markdown
+++ b/website/docs/r/group.html.markdown
@@ -19,36 +19,6 @@ a new group is created. When destroyed, it is removed.
 resource "opennebula_group" "example" {
   name = "group"
 
-  quotas {
-    datastore_quotas {
-      id     = 1
-      images = 3
-      size   = 10000
-    }
-    vm_quotas {
-      cpu            = 3
-      running_cpu    = 3
-      memory         = 2048
-      running_memory = 2048
-    }
-    network_quotas {
-      id     = 10
-      leases = 6
-    }
-    network_quotas {
-      id     = 11
-      leases = 4
-    }
-    image_quotas {
-      id          = 8
-      running_vms = 1
-    }
-    image_quotas {
-      id          = 9
-      running_vms = 1
-    }
-  }
-
   tags = {
     environment = "example"
   }
@@ -60,6 +30,42 @@ resource "opennebula_group" "example" {
    }
   }
 
+  lifecycle {
+	  ignore_changes = [
+	    "quotas"
+	  ]
+	}
+}
+
+resource "opennebula_group_quotas" "example" {
+  group_id = opennebula_group.example.id
+  datastore {
+    id     = 1
+    images = 3
+    size   = 10000
+  }
+  vm {
+    cpu            = 3
+    running_cpu    = 3
+    memory         = 2048
+    running_memory = 2048
+  }
+  network {
+    id     = 10
+    leases = 6
+  }
+  network {
+    id     = 11
+    leases = 4
+  }
+  image {
+    id          = 8
+    running_vms = 1
+  }
+  image {
+    id          = 9
+    running_vms = 1
+  }
 }
 ```
 
@@ -69,7 +75,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the group.
 * `admins` - (Optional) List of Administrator user IDs part of the group.
-* `quotas` - (Optional) See [Quotas parameters](#quotas-parameters) below for details
+* `quotas` - (Deprecated) See [Quotas parameters](#quotas-parameters) below for details. Use `resource_opennebula_group_quotas` instead.
 * `sunstone` - (Optional) Allow users and group admins to access specific views. See [Sunstone parameters](#sunstone-parameters) below for details
 * `opennebula` - (Optional) OpenNebula core configuration. See [Opennebula parameters](#opennebula-parameters) below for details
 * `tags` - (Optional) Group tags (Key = value)

--- a/website/docs/r/group_admins.html.markdown
+++ b/website/docs/r/group_admins.html.markdown
@@ -60,7 +60,7 @@ The following arguments are supported:
 
 ## Import
 
-`opennebula_group_admins` can be imported using its ID:
+`opennebula_group_admins` can be imported using the group ID:
 
 ```shell
 terraform import opennebula_group_admins.example 123

--- a/website/docs/r/group_quotas.markdown
+++ b/website/docs/r/group_quotas.markdown
@@ -1,0 +1,101 @@
+---
+layout: "opennebula"
+page_title: "OpenNebula: opennebula_group_quotas"
+sidebar_current: "docs-opennebula-resource-group"
+description: |-
+  Provides an OpenNebula group resource.
+---
+
+# opennebula_group_quotas
+
+Provides an OpenNebula group quotas resource.
+
+This resource allows you to manage the quotas for a group.
+
+
+## Example Usage
+
+```hcl
+resource "opennebula_group_quotas" "example" {
+    group_id = opennebula_group.example.id
+    datastore {
+      id     = 1
+      images = 5
+      size   = 10000
+    }
+    vm{
+      cpu            = 3
+      running_cpu    = 3
+      memory         = 2048
+      running_memory = 2048
+    }
+    network {
+      id     = 10
+      leases = 6
+    }
+    network {
+      id     = 11
+      leases = 4
+    }
+    image {
+      id          = 8
+      running_vms = 1
+    }
+    image {
+      id          = 9
+      running_vms = 1
+    }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `group_id` - (Required) The related group ID.
+* `datastore` - (Optional) List of datastore quotas. See [Datastore quotas parameters](#datastore-quotas-parameters) below for details.
+* `network` - (Optional) List of network quotas. See [Network quotas parameters](#network-quotas-parameters) below for details.
+* `image` - (Optional) List of image quotas. See [Image quotas parameters](#image-quotas-parameters) below for details
+* `vm` - (Optional) See [Virtual Machine quotas parameters](#virtual-machine-quotas-parameters) below for details
+
+#### Datastore quotas parameters
+
+`datastore` supports the following arguments:
+
+* `id` - (Required) Datastore ID.
+* `images` - (Optional) Maximum number of images allowed on the datastore. Defaults to `default quota`
+* `size` - (Optional) Total size in MB allowed on the datastore. Defaults to `default quota`
+
+#### Network quotas parameters
+
+`network` supports the following arguments:
+
+* `id` - (Required) Network ID.
+* `leases` - (Optional) Maximum number of ip leases allowed on the network. Defaults to `default quota`
+
+#### Image quotas parameters
+
+`image` supports the following arguments:
+
+* `id` - (Required) Image ID.
+* `running_vms` - (Optional) Maximum number of Virtual Machines in `RUNNING` state with this image ID attached. Defaults to `default quota`
+
+#### Virtual Machine quotas parameters
+
+`vm` supports the following arguments:
+
+* `cpu` - (Optional) Total of CPUs allowed. Defaults to `default quota`.
+* `memory` - (Optional) Total of memory (in MB) allowed. Defaults to `default quota`.
+* `vms` - (Optional) Maximum number of Virtual Machines allowed. Defaults to `default quota`.
+* `running_cpu` - (Optional) Virtual Machine CPUs allowed in `RUNNING` state. Defaults to `default quota`.
+* `running_memory` - (Optional) Virtual Machine Memory (in MB) allowed in `RUNNING` state. Defaults to `default quota`.
+* `running_vms` - (Optional) Number of Virtual Machines allowed in `RUNNING` state. Defaults to `default quota`.
+* `system_disk_size` - (Optional) Maximum disk global size (in MB) allowed on a `SYSTEM` datastore. Defaults to `default quota`.
+
+## Import
+
+`opennebula_group_quotas` can be imported using the group ID:
+
+```shell
+terraform import opennebula_group_quotas.example 123
+```

--- a/website/docs/r/group_quotas.markdown
+++ b/website/docs/r/group_quotas.markdown
@@ -23,12 +23,20 @@ resource "opennebula_group_quotas" "example" {
       images = 5
       size   = 10000
     }
-    vm{
+}
+
+resource "opennebula_group_quotas" "example" {
+    group_id = opennebula_group.example.id
+    vm {
       cpu            = 3
       running_cpu    = 3
       memory         = 2048
       running_memory = 2048
     }
+}
+
+resource "opennebula_group_quotas" "example" {
+    group_id = opennebula_group.example.id
     network {
       id     = 10
       leases = 6
@@ -37,6 +45,10 @@ resource "opennebula_group_quotas" "example" {
       id     = 11
       leases = 4
     }
+}
+
+resource "opennebula_group_quotas" "example" {
+    group_id = opennebula_group.example.id
     image {
       id          = 8
       running_vms = 1
@@ -53,10 +65,10 @@ resource "opennebula_group_quotas" "example" {
 The following arguments are supported:
 
 * `group_id` - (Required) The related group ID.
-* `datastore` - (Optional) List of datastore quotas. See [Datastore quotas parameters](#datastore-quotas-parameters) below for details.
-* `network` - (Optional) List of network quotas. See [Network quotas parameters](#network-quotas-parameters) below for details.
-* `image` - (Optional) List of image quotas. See [Image quotas parameters](#image-quotas-parameters) below for details
-* `vm` - (Optional) See [Virtual Machine quotas parameters](#virtual-machine-quotas-parameters) below for details
+* `datastore` - (Optional) List of datastore quotas. See [Datastore quotas parameters](#datastore-quotas-parameters) below for details. Conflicts with `network`, `image`, `vm`.
+* `network` - (Optional) List of network quotas. See [Network quotas parameters](#network-quotas-parameters) below for details. Conflicts with `datastore`, `image`, `vm`.
+* `image` - (Optional) List of image quotas. See [Image quotas parameters](#image-quotas-parameters) below for details. Conflicts with `datastore`, `network`, `vm`.
+* `vm` - (Optional) See [Virtual Machine quotas parameters](#virtual-machine-quotas-parameters) below for details. Conflicts with `datastore`, `network`, `image`.
 
 #### Datastore quotas parameters
 
@@ -94,8 +106,8 @@ The following arguments are supported:
 
 ## Import
 
-`opennebula_group_quotas` can be imported using the group ID:
+`opennebula_group_quotas` can be imported using the group ID and the quota section to import:
 
 ```shell
-terraform import opennebula_group_quotas.example 123
+terraform import opennebula_group_quotas.example 123:image
 ```

--- a/website/docs/r/user.html.markdown
+++ b/website/docs/r/user.html.markdown
@@ -23,36 +23,6 @@ resource "opennebula_user" "example" {
   primary_group = "100"
   groups        = [101, 102]
 
-  quotas {
-    datastore_quotas {
-      id     = 1
-      images = 3
-      size   = 10000
-    }
-    vm_quotas {
-      cpu            = 3
-      running_cpu    = 3
-      memory         = 2048
-      running_memory = 2048
-    }
-    network_quotas {
-      id     = 10
-      leases = 6
-    }
-    network_quotas {
-      id     = 11
-      leases = 4
-    }
-    image_quotas {
-      id          = 8
-      running_vms = 1
-    }
-    image_quotas {
-      id          = 9
-      running_vms = 1
-    }
-  }
-
   tags = {
     environment = "example"
   }
@@ -63,6 +33,43 @@ resource "opennebula_user" "example" {
       key1 = "value1"
    }
   }
+
+  lifecycle {
+	  ignore_changes = [
+	    "quotas"
+	  ]
+	}
+}
+
+resource "opennebula_user_quotas" "example" {
+    user_id = opennebula_user.example.id
+    datastore {
+      id     = 1
+      images = 3
+      size   = 10000
+    }
+    vm {
+      cpu            = 3
+      running_cpu    = 3
+      memory         = 2048
+      running_memory = 2048
+    }
+    network {
+      id     = 10
+      leases = 6
+    }
+    network {
+      id     = 11
+      leases = 4
+    }
+    image {
+      id          = 8
+      running_vms = 1
+    }
+    image {
+      id          = 9
+      running_vms = 1
+    }
 }
 ```
 
@@ -75,7 +82,7 @@ The following arguments are supported:
 * `auth_driver` - (Optional) Authentication Driver for User management. DEfaults to 'core'.
 * `primary_group` - (Optional) Primary group ID of the User. Defaults to 0 (oneadmin).
 * `groups` - (Optional) List of secondary groups ID of the user.
-* `quotas` - (Optional) See [Quotas parameters](#quotas-parameters) below for details
+* `quotas` - (Deprecated) See [Quotas parameters](#quotas-parameters) below for details. Use `resource_opennebula_user_quotas` instead.
 * `ssh_public_key` - (Optional) SSH public key.
 * `tags` - (Optional) Group tags (Key = value)
 * `template_section` - (Optional) Allow to add a custom vector. See [Template section parameters](#template-section-parameters)

--- a/website/docs/r/user_quotas.markdown
+++ b/website/docs/r/user_quotas.markdown
@@ -15,19 +15,27 @@ This resource allows you to manage the quotas for an user.
 ## Example Usage
 
 ```hcl
-resource "opennebula_user_quotas" "example" {
+resource "opennebula_user_quotas" "datastore_example" {
     user_id = opennebula_user.example.id
     datastore {
       id     = 1
       images = 5
       size   = 10000
     }
+}
+
+resource "opennebula_user_quotas" "vm_example" {
+    user_id = opennebula_user.example.id
     vm {
       cpu            = 3
       running_cpu    = 3
       memory         = 2048
       running_memory = 2048
     }
+}
+
+resource "opennebula_user_quotas" "network_example" {
+    user_id = opennebula_user.example.id
     network {
       id     = 10
       leases = 6
@@ -36,6 +44,10 @@ resource "opennebula_user_quotas" "example" {
       id     = 11
       leases = 4
     }
+}
+
+resource "opennebula_user_quotas" "image_example" {
+    user_id = opennebula_user.example.id
     image {
       id          = 8
       running_vms = 1
@@ -52,10 +64,10 @@ resource "opennebula_user_quotas" "example" {
 The following arguments are supported:
 
 * `user_id` - (Required) The related user ID.
-* `datastore` - (Optional) List of datastore quotas. See [Datastore quotas parameters](#datastore-quotas-parameters) below for details.
-* `network` - (Optional) List of network quotas. See [Network quotas parameters](#network-quotas-parameters) below for details.
-* `image` - (Optional) List of image quotas. See [Image quotas parameters](#image-quotas-parameters) below for details
-* `vm` - (Optional) See [Virtual Machine quotas parameters](#virtual-machine-quotas-parameters) below for details
+* `datastore` - (Optional) List of datastore quotas. See [Datastore quotas parameters](#datastore-quotas-parameters) below for details. Conflicts with `network`, `image`, `vm`.
+* `network` - (Optional) List of network quotas. See [Network quotas parameters](#network-quotas-parameters) below for details. Conflicts with `datastore`, `image`, `vm`.
+* `image` - (Optional) List of image quotas. See [Image quotas parameters](#image-quotas-parameters) below for details. Conflicts with `datastore`, `network`, `vm`.
+* `vm` - (Optional) See [Virtual Machine quotas parameters](#virtual-machine-quotas-parameters) below for details. Conflicts with `datastore`, `network`, `image`.
 
 #### Datastore quotas parameters
 
@@ -93,8 +105,8 @@ The following arguments are supported:
 
 ## Import
 
-`opennebula_user_quotas` can be imported using the user ID:
+`opennebula_user_quotas` can be imported using the user ID and the quotas section to import:
 
 ```shell
-terraform import opennebula_user_quotas.example 123
+terraform import opennebula_user_quotas.example 123:datastore
 ```

--- a/website/docs/r/user_quotas.markdown
+++ b/website/docs/r/user_quotas.markdown
@@ -1,0 +1,100 @@
+---
+layout: "opennebula"
+page_title: "OpenNebula: opennebula_user_quotas"
+sidebar_current: "docs-opennebula-resource-user"
+description: |-
+  Provides an OpenNebula user resource.
+---
+
+# opennebula_user_quotas
+
+Provides an OpenNebula user quotas resource.
+
+This resource allows you to manage the quotas for an user.
+
+## Example Usage
+
+```hcl
+resource "opennebula_user_quotas" "example" {
+    user_id = opennebula_user.example.id
+    datastore {
+      id     = 1
+      images = 5
+      size   = 10000
+    }
+    vm {
+      cpu            = 3
+      running_cpu    = 3
+      memory         = 2048
+      running_memory = 2048
+    }
+    network {
+      id     = 10
+      leases = 6
+    }
+    network {
+      id     = 11
+      leases = 4
+    }
+    image {
+      id          = 8
+      running_vms = 1
+    }
+    image {
+      id          = 9
+      running_vms = 1
+    }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `user_id` - (Required) The related user ID.
+* `datastore` - (Optional) List of datastore quotas. See [Datastore quotas parameters](#datastore-quotas-parameters) below for details.
+* `network` - (Optional) List of network quotas. See [Network quotas parameters](#network-quotas-parameters) below for details.
+* `image` - (Optional) List of image quotas. See [Image quotas parameters](#image-quotas-parameters) below for details
+* `vm` - (Optional) See [Virtual Machine quotas parameters](#virtual-machine-quotas-parameters) below for details
+
+#### Datastore quotas parameters
+
+`datastore` supports the following arguments:
+
+* `id` - (Required) Datastore ID.
+* `images` - (Optional) Maximum number of images allowed on the datastore. Defaults to `default quota`
+* `size` - (Optional) Total size in MB allowed on the datastore. Defaults to `default quota`
+
+#### Network quotas parameters
+
+`network` supports the following arguments:
+
+* `id` - (Required) Network ID.
+* `leases` - (Optional) Maximum number of ip leases allowed on the network. Defaults to `default quota`
+
+#### Image quotas parameters
+
+`image` supports the following arguments:
+
+* `id` - (Required) Image ID.
+* `running_vms` - (Optional) Maximum number of Virtual Machines in `RUNNING` state with this image ID attached. Defaults to `default quota`
+
+#### Virtual Machine quotas parameters
+
+`vm` supports the following arguments:
+
+* `cpu` - (Optional) Total of CPUs allowed. Defaults to `default quota`.
+* `memory` - (Optional) Total of memory (in MB) allowed. Defaults to `default quota`.
+* `vms` - (Optional) Maximum number of Virtual Machines allowed. Defaults to `default quota`.
+* `running_cpu` - (Optional) Virtual Machine CPUs allowed in `RUNNING` state. Defaults to `default quota`.
+* `running_memory` - (Optional) Virtual Machine Memory (in MB) allowed in `RUNNING` state. Defaults to `default quota`.
+* `running_vms` - (Optional) Number of Virtual Machines allowed in `RUNNING` state. Defaults to `default quota`.
+* `system_disk_size` - (Optional) Maximum disk global size (in MB) allowed on a `SYSTEM` datastore. Defaults to `default quota`.
+
+## Import
+
+`opennebula_user_quotas` can be imported using the user ID:
+
+```shell
+terraform import opennebula_user_quotas.example 123
+```


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

<!--- Please leave a helpful description of the PR here. --->

Until now quotas are only a schema part (via some nested typeset and typelists) of the users ans group resources, this PR externalize quotas in their own resource.
One resource for the users, another for the groups.

After some tests it's possible to define several quota resource for a single user or a signle group.

### References

Close #447
Close #448

### New or Affected Resource(s)

<!--- Please list the new or affected resources and data sources. --->

- opennebula_group
- opennebula_group_quotas
- opennebula_user
- opennebula_user_quotas

### Checklist

<!--- Please check you didn't forgot a step to help us merging this PR. --->

- [ ] I have created an issue and I have mentioned it in `References`
- [ ] My code follows the style guidelines of this project (use `go fmt`)
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the unit tests and they pass succesfuly
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation (if needed)
- [ ] I have updated the changelog file
