### PR TITLE
Rename cpumodel to cpu_model

### DIFF
--- a/opennebula/resource_opennebula_template.go
+++ b/opennebula/resource_opennebula_template.go
@@ -761,13 +761,13 @@ func resourceOpennebulaTemplateUpdateCustom(ctx context.Context, d *schema.Resou
 		update = true
 	}
 
-	if d.HasChange("cpumodel") {
+	if d.HasChange("cpu_model") {
 		newTpl.Del("CPU_MODEL")
-		cpumodel := d.Get("cpumodel").([]interface{})
+		cpu_model := d.Get("cpu_model").([]interface{})
 
-		for i := 0; i < len(cpumodel); i++ {
-			cpumodelconfig := cpumodel[i].(map[string]interface{})
-			newTpl.CPUModel(cpumodelconfig["model"].(string))
+		for i := 0; i < len(cpu_model); i++ {
+			cpu_modelconfig := cpu_model[i].(map[string]interface{})
+			newTpl.CPUModel(cpu_modelconfig["model"].(string))
 		}
 
 	}

--- a/opennebula/resource_opennebula_template_test.go
+++ b/opennebula/resource_opennebula_template_test.go
@@ -64,7 +64,7 @@ func TestAccTemplate(t *testing.T) {
 			{
 				Config: testAccTemplateCPUModel,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("opennebula_template.template", "name", "terra-tpl-cpumodel"),
+					resource.TestCheckResourceAttr("opennebula_template.template", "name", "terra-tpl-cpu_model"),
 					resource.TestCheckResourceAttr("opennebula_template.template", "permissions", "660"),
 					resource.TestCheckResourceAttr("opennebula_template.template", "group", "oneadmin"),
 					resource.TestCheckResourceAttr("opennebula_template.template", "cpu", "0.5"),
@@ -75,8 +75,8 @@ func TestAccTemplate(t *testing.T) {
 					resource.TestCheckResourceAttr("opennebula_template.template", "os.#", "1"),
 					resource.TestCheckResourceAttr("opennebula_template.template", "os.0.arch", "x86_64"),
 					resource.TestCheckResourceAttr("opennebula_template.template", "os.0.boot", ""),
-					resource.TestCheckResourceAttr("opennebula_template.template", "cpumodel.#", "1"),
-					resource.TestCheckResourceAttr("opennebula_template.template", "cpumodel.0.model", "host-passthrough"),
+					resource.TestCheckResourceAttr("opennebula_template.template", "cpu_model.#", "1"),
+					resource.TestCheckResourceAttr("opennebula_template.template", "cpu_model.0.model", "host-passthrough"),
 					resource.TestCheckResourceAttr("opennebula_template.template", "tags.%", "2"),
 					resource.TestCheckResourceAttr("opennebula_template.template", "tags.env", "prod"),
 					resource.TestCheckResourceAttr("opennebula_template.template", "tags.customer", "test"),
@@ -294,7 +294,7 @@ resource "opennebula_template" "template" {
 
 var testAccTemplateCPUModel = `
 resource "opennebula_template" "template" {
-  name = "terra-tpl-cpumodel"
+  name = "terra-tpl-cpu_model"
   permissions = "660"
   group = "oneadmin"
   cpu = "0.5"
@@ -313,7 +313,7 @@ resource "opennebula_template" "template" {
     type = "VNC"
   }
 
-  cpumodel {
+  cpu_model {
     model = "host-passthrough"
   }
 

--- a/opennebula/resource_opennebula_virtual_machine_test.go
+++ b/opennebula/resource_opennebula_virtual_machine_test.go
@@ -509,8 +509,8 @@ func TestAccVirtualMachineCPUModel(t *testing.T) {
 					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "os.#", "1"),
 					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "os.0.arch", "x86_64"),
 					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "os.0.boot", ""),
-					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "cpumodel.#", "1"),
-					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "cpumodel.0.model", "host-passthrough"),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "cpu_model.#", "1"),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "cpu_model.0.model", "host-passthrough"),
 					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "disk.#", "0"),
 					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "tags.%", "2"),
 					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "tags.env", "dev"),
@@ -602,7 +602,7 @@ resource "opennebula_virtual_machine" "test" {
     boot = ""
   }
 
-  cpumodel {
+  cpu_model {
     model = "host-passthrough"
   }
 

--- a/opennebula/shared_schemas.go
+++ b/opennebula/shared_schemas.go
@@ -89,7 +89,7 @@ func commonInstanceSchema() map[string]*schema.Schema {
 		"vcpu":         vcpuSchema(),
 		"memory":       memorySchema(),
 		"context":      contextSchema(),
-		"cpumodel":     cpumodelSchema(),
+		"cpu_model":    cpu_modelSchema(),
 		"graphics":     graphicsSchema(),
 		"os":           osSchema(),
 		"vmgroup":      vmGroupSchema(),
@@ -295,7 +295,7 @@ func contextSchema() *schema.Schema {
 	}
 }
 
-func cpumodelSchema() *schema.Schema {
+func cpu_modelSchema() *schema.Schema {
 	return &schema.Schema{
 		Type:        schema.TypeList,
 		Optional:    true,
@@ -604,10 +604,10 @@ func generateVMTemplate(d *schema.ResourceData, tpl *vm.Template) error {
 	addOS(tpl, d.Get("os").([]interface{}))
 
 	//Generate CPU Model definition
-	cpumodel := d.Get("cpumodel").([]interface{})
-	for i := 0; i < len(cpumodel); i++ {
-		cpumodelconfig := cpumodel[i].(map[string]interface{})
-		tpl.CPUModel(cpumodelconfig["model"].(string))
+	cpu_model := d.Get("cpu_model").([]interface{})
+	for i := 0; i < len(cpu_model); i++ {
+		cpu_modelconfig := cpu_model[i].(map[string]interface{})
+		tpl.CPUModel(cpu_modelconfig["model"].(string))
 	}
 
 	//Generate VM Group definition
@@ -760,8 +760,8 @@ func flattenTemplate(d *schema.ResourceData, inheritedVectors map[string]interfa
 	arch, _ := vmTemplate.GetOS(vmk.Arch)
 	boot, _ := vmTemplate.GetOS(vmk.Boot)
 	// CPU Model
-	cpumodelMap := make([]map[string]interface{}, 0, 1)
-	cpumodel, _ := vmTemplate.GetCPUModel(vmk.Model)
+	cpu_modelMap := make([]map[string]interface{}, 0, 1)
+	cpu_model, _ := vmTemplate.GetCPUModel(vmk.Model)
 	// Graphics
 	graphMap := make([]map[string]interface{}, 0, 1)
 	listen, _ := vmTemplate.GetIOGraphic(vmk.Listen)
@@ -791,13 +791,13 @@ func flattenTemplate(d *schema.ResourceData, inheritedVectors map[string]interfa
 	}
 
 	// Set CPU Model to resource
-	if cpumodel != "" {
-		cpumodelMap = append(cpumodelMap, map[string]interface{}{
-			"model": cpumodel,
+	if cpu_model != "" {
+		cpu_modelMap = append(cpu_modelMap, map[string]interface{}{
+			"model": cpu_model,
 		})
 		_, inherited := inheritedVectors["CPU_MODEL"]
 		if !inherited {
-			err = d.Set("cpumodel", cpumodelMap)
+			err = d.Set("cpu_model", cpu_modelMap)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

<!--- Please leave a helpful description of the PR here. --->

Rename virtual machine resource attribute `cpumodel` to `cpu_model`

### References

#451 

### New or Affected Resource(s)

<!--- Please list the new or affected resources and data sources. --->

- opennebula_virtual_machine

### Checklist

<!--- Please check you didn't forgot a step to help us merging this PR. --->

- [ ] I have created an issue and I have mentioned it in `References`
- [ ] My code follows the style guidelines of this project (use `go fmt`)
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the unit tests and they pass succesfuly
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation (if needed)
- [ ] I have updated the changelog file
