### PR TITLE
Fix incorrect virtual network key during import of virtual_network_address_range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.2.2 (Unreleased)
+
+BUG FIXES:
+
+* resources/virtual_network_address_range: fix failing import due to incorrect virtual network key
+
 # 1.2.1 (April 26th, 2023)
 
 FEATURES:

--- a/opennebula/resource_opennebula_virtual_network_address_range.go
+++ b/opennebula/resource_opennebula_virtual_network_address_range.go
@@ -553,7 +553,7 @@ func resourceOpennebulaVirtualNetworkAddressRangeImportState(ctx context.Context
 	}
 
 	d.SetId(parts[1])
-	d.Set("vnet_id", vmID)
+	d.Set("virtual_network_id", vmID)
 
 	return []*schema.ResourceData{d}, nil
 }


### PR DESCRIPTION
Fixes #456

<!--- Please keep this note for the community --->

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

<!--- Please leave a helpful description of the PR here. --->

Fix incorrect virtual network key during import of virtual_network_address_range

### References

Close #456

### New or Affected Resource(s)

<!--- Please list the new or affected resources and data sources. --->

- opennebula_virtual_network

### Checklist

<!--- Please check you didn't forgot a step to help us merging this PR. --->

- [x] I have created an issue and I have mentioned it in `References`
- [x] My code follows the style guidelines of this project (use `go fmt`)
- [x] My changes generate no new warnings or errors
- [ ] I have updated the unit tests and they pass succesfuly
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation (if needed)
- [x] I have updated the changelog file
