### PR TITLE
Extend optional disabling of TLS verification to the flow client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ BUG FIXES:
 
 * data/opennebula_template: fix filtering (#479)
 
+ENHANCEMENTS:
+
+* provider: `insecure` attribute now also skips TLS verification for the flow client (#482)
+
 # 1.3.0 (July 28th, 2023)
 
 FEATURES:

--- a/opennebula/provider.go
+++ b/opennebula/provider.go
@@ -209,10 +209,11 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 
 	flowEndpoint, ok := d.GetOk("flow_endpoint")
 	if ok {
-		flowClient := goca.NewDefaultFlowClient(
+		flowClient := goca.NewFlowClient(
 			goca.NewFlowConfig(username.(string),
 				password.(string),
-				flowEndpoint.(string)))
+				flowEndpoint.(string)),
+			&http.Client{Transport: tr})
 
 		cfg.Controller = goca.NewGenericController(oneClient, flowClient)
 		return cfg, nil


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

Extend optional disabling of TLS verification to the flow client

### References

https://github.com/OpenNebula/terraform-provider-opennebula/issues/482

### New or Affected Resource(s)

<!--- Please list the new or affected resources and data sources. --->

N/A

### Checklist

<!--- Please check you didn't forgot a step to help us merging this PR. --->

- [x] I have created an issue and I have mentioned it in `References`
- [x] My code follows the style guidelines of this project (use `go fmt`)
- [x] My changes generate no new warnings or errors
- [x] I have updated the unit tests and they pass succesfuly
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation (if needed)
- [x] I have updated the changelog file
