### PR TITLE
M #445: Fix flow_endpoint example in docs

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -41,7 +41,7 @@ The configuration of the OpenNebula Provider can be set by the `provider` block 
 ### Provider attributes
 
 * `endpoint` - (Required) The URL of OpenNebula XML-RPC Endpoint API (for example, `http://example.com:2633/RPC2`).
-* `flow_endpoint` - (Optional) The OneFlow HTTP Endpoint API (for example, `http://example.com:2474/RPC2`).
+* `flow_endpoint` - (Optional) The OneFlow HTTP Endpoint API (for example, `http://example.com:2474`).
 * `username` - (Required) The OpenNebula username.
 * `password` - (Required) The Opennebula password matching the username.
 * `insecure` - (Optional) Allow insecure connexion (skip TLS verification).
@@ -63,7 +63,7 @@ The provider can also read the following environment variables if no value is se
 
 ```bash
 export OPENNEBULA_ENDPOINT="https://example.com:2633/RPC2"
-export OPENNEBULA_FLOW_ENDPOINT="https://example.com:2474/RPC2"
+export OPENNEBULA_FLOW_ENDPOINT="https://example.com:2474"
 export OPENNEBULA_USERNAME="me"
 export OPENNEBULA_PASSWORD="p@s5w0rD"
 export OPENNEBULA_INSECURE="true"


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

The example endpoint for `flow_endpoint` in the documentation is not valid. The `/RPC2` path only applies to the OpenNebula endpoint. If a user copies this as an example, the OneFlow server will return errors.

### References

#445 

### New or Affected Resource(s)


- opennebula_service

### Checklist

<!--- Please check you didn't forgot a step to help us merging this PR. --->

- [x] I have created an issue and I have mentioned it in `References`
- [x] My code follows the style guidelines of this project (use `go fmt`)
- [x] My changes generate no new warnings or errors
- [x] I have updated the unit tests and they pass succesfuly
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation (if needed)
- [x] I have updated the changelog file
