### PR TITLE
F-498: add support for `passwd` and `random_passwd` arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ ENHANCEMENTS:
 
 * resources/opennebula_virtual_machine: add `nic` scheduling attributes: `network_mode_auto`, `sched_requirements`, `sched_rank`. (#477)
 * resources/opennebula_template: add `nic` scheduling attributes: `network_mode_auto`, `sched_requirements`, `sched_rank`. (#477)
+* resources/opennebula_virtual_machine: adds `passwd` and `random_passwd` fields to `graphics` section. (#498)
+* resources/opennebula_template: adds `passwd` and `random_passwd` fields to `graphics` section. (#498)
 
 BUG FIXES:
 

--- a/opennebula/shared_schemas.go
+++ b/opennebula/shared_schemas.go
@@ -382,6 +382,16 @@ func graphicsSchema() *schema.Schema {
 					Optional: true,
 					Default:  "en-us",
 				},
+				"passwd": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					ConflictsWith: []string{"graphics.0.random_passwd"},
+				},
+				"random_passwd": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					ConflictsWith: []string{"graphics.0.passwd"},
+				},
 			},
 		},
 	}
@@ -619,6 +629,11 @@ func addGraphic(tpl *vm.Template, graphics []interface{}) {
 				tpl.AddIOGraphic(vmk.Port, v.(string))
 			case "keymap":
 				tpl.AddIOGraphic(vmk.Keymap, v.(string))
+			case "passwd":
+				tpl.AddIOGraphic(vmk.Passwd, v.(string))
+			case "random_passwd":
+				// Convert bool to string
+				tpl.AddIOGraphic(vmk.RandomPassword, map[bool]string{true: "YES", false: "NO"}[v.(bool)])
 			}
 
 		}
@@ -906,6 +921,8 @@ func flattenTemplate(d *schema.ResourceData, inheritedVectors map[string]interfa
 	port, _ := vmTemplate.GetIOGraphic(vmk.Port)
 	t, _ := vmTemplate.GetIOGraphic(vmk.GraphicType)
 	keymap, _ := vmTemplate.GetIOGraphic(vmk.Keymap)
+	passwd, _ := vmTemplate.GetIOGraphic(vmk.Passwd)
+	random_passwd, _ := vmTemplate.GetIOGraphic(vmk.RandomPassword)
 	// Raw
 	rawVec, _ := vmTemplate.GetVector("RAW")
 
@@ -967,10 +984,12 @@ func flattenTemplate(d *schema.ResourceData, inheritedVectors map[string]interfa
 	// Set graphics to resource
 	if port != "" {
 		graphMap = append(graphMap, map[string]interface{}{
-			"listen": listen,
-			"port":   port,
-			"type":   t,
-			"keymap": keymap,
+			"listen":        listen,
+			"port":          port,
+			"type":          t,
+			"keymap":        keymap,
+			"passwd":        passwd,
+			"random_passwd": random_passwd,
 		})
 		_, inherited := inheritedVectors["GRAPHICS"]
 		if !inherited {

--- a/website/docs/r/template.html.markdown
+++ b/website/docs/r/template.html.markdown
@@ -114,6 +114,8 @@ The following arguments are supported:
 * `listen` - (Required) Binding address.
 * `port` - (Optional) Binding Port.
 * `keymap` - (Optional) Keyboard mapping.
+* `passwd` - (Optional) VNC's password, conflicts with random_passwd.
+* `random_passwd` - (Optional) Randomized VNC's password, conflicts with passwd.
 
 ### OS parameters
 

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -117,6 +117,8 @@ The following arguments are supported:
 * `listen` - (Required) Binding address.
 * `port` - (Optional) Binding Port.
 * `keymap` - (Optional) Keyboard mapping.
+* `passwd` - (Optional) VNC's password, conflicts with random_passwd.
+* `random_passwd` - (Optional) Randomized VNC's password, conflicts with passwd.
 
 ### OS parameters
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

Adds support for `passwd` and `random_passwd` arguments for `graphics` section for VNC so we avoid the following:
```
│ Error: Unsupported argument
│
│ on ../../_modules/instance/instance.tf line 33, in resource "opennebula_virtual_machine" "instance":
│ 33: passwd = substr(base64encode(random_string.password.result), 0, 8)
│
│ An argument named "passwd" is not expected here.
<!--- Please leave a helpful description of the PR here. --->
```
### References

#498: Add `passwd` and `random_passwd` arguments for opennebula_virtual_machine and opennebula_template `graphics` sections

### New or Affected Resource(s)

<!--- Please list the new or affected resources and data sources. --->

- `opennebula_virtual_machine`
- `opennebula_template`

### Checklist

<!--- Please check you didn't forgot a step to help us merging this PR. --->

- [x] I have created an issue and I have mentioned it in `References`
- [x] My code follows the style guidelines of this project (use `go fmt`)
- [x] My changes generate no new warnings or errors
- [ ] I have updated the unit tests and they pass succesfuly - NA
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation (if needed)
- [x] I have updated the changelog file
