### PR TITLE
Fix wrong attribute in a vnet example

### DIFF
--- a/website/docs/r/virtual_network.html.markdown
+++ b/website/docs/r/virtual_network.html.markdown
@@ -45,7 +45,7 @@ resource "opennebula_virtual_network" "example" {
   dns             = "172.16.100.1"
   gateway         = "172.16.100.1"
   security_groups = [0]
-  clusters_ids    = [0]
+  cluster_ids    = [0]
 
   ar {
     ar_type = "IP4"


### PR DESCRIPTION
### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

### Description

Minor change, the correct attribute name is "cluster_ids". Not opening a new issue since it's just a minor fix (but can do if required).

### New or Affected Resource(s)

- opennebula_virtual_netwwork

### Checklist

<!--- Please check you didn't forgot a step to help us merging this PR. --->

- [x] I have updated the documentation (if needed)

