### PR TITLE
B #468: Improve `service_template` indempotence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ FEATURES:
 BUG FIXES:
 
 * resources/opennebula_virtual_machine: fix `cpumodel` update (#463)
+* resources/opennebula_service_template: improve `service_template` idempotency (#468)
 
 # 1.3.1 (September 11st, 2023)
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

This PR introduces an improvement t to the handling of Service Template objects in the Terraform provider for OpenNebula. 

Key changes include:

1. **Custom Deep Equality Function**: A custom `deepEqualIgnoreEmpty` function has been added to the `DiffSuppressFunc` for the Service Template resource. This function compares two Service Template objects, ignoring empty fields. This change allows to improve the service idempotency since there're inconsistencies between the objects stored in the Terraform state and the values returned by the OneFlow API (which does NOT return empty objects). This caused terraform to interpret false changes that now no longer occur.

2. **JSON Unmarshalling**: The old and new states of the Service Template object are now unmarshalled into `ServiceTemplate` structs before being compared. This allows the `deepEqualIgnoreEmpty` function to compare the objects field by field, rather than as raw JSON strings.

### References

#468 

### New or Affected Resource(s)

<!--- Please list the new or affected resources and data sources. --->

- opennebula_resource_service_template

### Checklist

<!--- Please check you didn't forgot a step to help us merging this PR. --->

- [x] I have created an issue and I have mentioned it in `References`
- [x] My code follows the style guidelines of this project (use `go fmt`)
- [x] My changes generate no new warnings or errors
- [x] I have updated the unit tests and they pass succesfuly
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation (if needed)
- [x] I have updated the changelog file
