### PR TITLE
F #512: Fix the `reservation_ar_id=0` case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ BUG FIXES:
 * resources/opennebula_virtual_machine: fix `cpumodel` update (#463)
 * resources/opennebula_service_template: improve `service_template` idempotency (#468)
 * resources/opennebula_service: fix service crashes (#469)
+* resources/opennebula_virtual_network: fix the `reservation_ar_id=0` case (#512)
 
 # 1.3.1 (September 11st, 2023)
 

--- a/opennebula/resource_opennebula_virtual_network.go
+++ b/opennebula/resource_opennebula_virtual_network.go
@@ -408,7 +408,7 @@ func resourceOpennebulaVirtualNetworkCreate(ctx context.Context, d *schema.Resou
 		if reservationFirstIP, ok := d.GetOk("reservation_first_ip"); ok {
 			reservationTemplate.AddPair("IP", reservationFirstIP.(string))
 		}
-		if reservationARID, ok := d.GetOk("reservation_ar_id"); ok && reservationARID != -1 {
+		if reservationARID := d.Get("reservation_ar_id"); reservationARID != -1 {
 			reservationTemplate.AddPair("AR_ID", reservationARID.(int))
 		}
 		reservationSize, ok := d.GetOk("reservation_size")

--- a/opennebula/resource_opennebula_virtual_network_test.go
+++ b/opennebula/resource_opennebula_virtual_network_test.go
@@ -190,14 +190,17 @@ func TestAccVirtualNetwork(t *testing.T) {
 			{
 				Config: testAccVirtualNetworkReservationConfig,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("opennebula_virtual_network.reservation", "name", "terravnetres"),
-					resource.TestCheckResourceAttr("opennebula_virtual_network.reservation", "reservation_size", "5"),
-					resource.TestCheckResourceAttr("opennebula_virtual_network.reservation", "reservation_first_ip", "172.16.100.115"),
-					resource.TestCheckResourceAttr("opennebula_virtual_network.reservation", "permissions", "660"),
-					resource.TestCheckResourceAttrSet("opennebula_virtual_network.reservation", "uid"),
-					resource.TestCheckResourceAttrSet("opennebula_virtual_network.reservation", "gid"),
-					resource.TestCheckResourceAttrSet("opennebula_virtual_network.reservation", "uname"),
-					resource.TestCheckResourceAttrSet("opennebula_virtual_network.reservation", "gname"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network.reservation1", "name", "terravnetres"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network.reservation1", "reservation_size", "5"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network.reservation1", "reservation_first_ip", "172.16.100.115"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network.reservation1", "permissions", "660"),
+					resource.TestCheckResourceAttrSet("opennebula_virtual_network.reservation1", "uid"),
+					resource.TestCheckResourceAttrSet("opennebula_virtual_network.reservation1", "gid"),
+					resource.TestCheckResourceAttrSet("opennebula_virtual_network.reservation1", "uname"),
+					resource.TestCheckResourceAttrSet("opennebula_virtual_network.reservation1", "gname"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network.reservation2", "name", "zero_ar_id"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network.reservation2", "reservation_size", "2"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network.reservation2", "reservation_first_ip", "172.16.100.3"),
 					testAccCheckVirtualNetworkPermissions(&shared.Permissions{
 						OwnerU: 1,
 						OwnerM: 1,
@@ -563,13 +566,23 @@ resource "opennebula_virtual_network_address_range" "test4" {
 	size               = 2
 }
 
-resource "opennebula_virtual_network" "reservation" {
+resource "opennebula_virtual_network" "reservation1" {
     name = "terravnetres"
     description = "my terraform vnet"
     reservation_vnet = opennebula_virtual_network.test.id
     reservation_size = 5
 	reservation_ar_id = opennebula_virtual_network_address_range.test.id
 	reservation_first_ip = "172.16.100.115"
+    security_groups = [0]
+    permissions = 660
+}
+
+resource "opennebula_virtual_network" "reservation2" {
+    name = "zero_ar_id"
+    reservation_vnet = opennebula_virtual_network.test.id
+    reservation_size = 2
+	reservation_ar_id = 0
+	reservation_first_ip = "172.16.100.3"
     security_groups = [0]
     permissions = 660
 }


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

<!--- Please leave a helpful description of the PR here. --->

Use `d.Get` instead of `d.GetOk` to allow `reservation_ar_id` to take the value of 0.

### References

#512

### New or Affected Resource(s)

<!--- Please list the new or affected resources and data sources. --->

- opennebula_virtual_network

### Checklist

<!--- Please check you didn't forgot a step to help us merging this PR. --->

- [x] I have created an issue and I have mentioned it in `References`
- [x] My code follows the style guidelines of this project (use `go fmt`)
- [x] My changes generate no new warnings or errors
- [x] I have updated the unit tests and they pass succesfuly
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation (if needed)
- [x] I have updated the changelog file
