### PR TITLE
B-518: Fix state `LOCKED` not supported while creating marketplace app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ FEATURES:
 
 * **New Resource**: `opennebula_marketplace` (#414)
 * **New Data Source**: `opennebula_marketplace` (#414)
-* **New Resource**: `opennebula_marketplace_appliance` (#476)
+* **New Resource**: `opennebula_marketplace_appliance` (#476, #518)
 * **New Data Source**: `opennebula_marketplace_appliance` (#476)
 * resources/opennebula_virtual_router_nic: add floating IP allocation (#510)
 
@@ -412,7 +412,8 @@ DEPRECATION:
 
 FEATURES:
 
-* **New Resource**** New Data Source**: opennebula_user : First implementation ([#69](https://github.com/OpenNebula/terraform-provider-opennebula/issues/69))
+* **New Resource**: opennebula_user : First implementation ([#69](https://github.com/OpenNebula/terraform-provider-opennebula/issues/69))
+* **New Data Source**: opennebula_user : First implementation ([#69](https://github.com/OpenNebula/terraform-provider-opennebula/issues/69))
 * resources/opennebula_virtual_machine: Enable VM disk update ([#64](https://github.com/OpenNebula/terraform-provider-opennebula/issues/64))
 * resources/opennebula_virtual_machine: Change 'image_id' disk attribute from Required to Optional ([#71](https://github.com/OpenNebula/terraform-provider-opennebula/issues/71))
 * **New Resource**: `opennebula_service`: First implementation ([oneflow](http://docs.opennebula.io/5.12/integration/system_interfaces/appflow_api.html#service)),

--- a/opennebula/resource_opennebula_marketplace_app.go
+++ b/opennebula/resource_opennebula_marketplace_app.go
@@ -287,7 +287,7 @@ func resourceOpennebulaMarketPlaceAppCreate(ctx context.Context, d *schema.Resou
 	ac := controller.MarketPlaceApp(appID)
 
 	timeout := d.Timeout(schema.TimeoutCreate)
-	_, err = waitForMarketAppStates(ctx, ac, timeout, []string{app.Init.String(), app.Ready.String()}, []string{app.Ready.String()})
+	_, err = waitForMarketAppStates(ctx, ac, timeout, []string{app.Init.String(), app.Ready.String(), app.Locked.String()}, []string{app.Ready.String()})
 	if err != nil {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

<!--- Please leave a helpful description of the PR here. --->

Fix an issue where the state `LOCKED` is not included for waiting the `READY` state.

### References

#518 

### New or Affected Resource(s)

<!--- Please list the new or affected resources and data sources. --->

- opennebula_marketplace_appliance

### Checklist

<!--- Please check you didn't forgot a step to help us merging this PR. --->

- [x] I have created an issue and I have mentioned it in `References`
- [x] My code follows the style guidelines of this project (use `go fmt`)
- [x] My changes generate no new warnings or errors
- [x] I have updated the unit tests and they pass succesfuly
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation (if needed)
- [x] I have updated the changelog file
