### PR TITLE
Fixed type assertion panic in network ID retrieval

### DIFF
--- a/opennebula/resource_opennebula_service.go
+++ b/opennebula/resource_opennebula_service.go
@@ -355,7 +355,6 @@ func resourceOpennebulaServiceRead(ctx context.Context, d *schema.ResourceData, 
 	}
 	d.Set("networks", networks)
 
-
 	// Retrieve roles
 	var roles []map[string]interface{}
 	for _, role := range sv.Template.Body.Roles {

--- a/opennebula/resource_opennebula_service.go
+++ b/opennebula/resource_opennebula_service.go
@@ -314,7 +314,33 @@ func resourceOpennebulaServiceRead(ctx context.Context, d *schema.ResourceData, 
 	var networks = make(map[string]int)
 	for _, val := range sv.Template.Body.NetworksVals {
 		for k, v := range val {
-			s := v.(map[string]interface{})["id"].(string)
+			if v == nil {
+				diags = append(diags, diag.Diagnostic{
+					Severity: diag.Error,
+					Summary:  "Network ID is nil",
+					Detail:   fmt.Sprintf("service (ID: %s): Network ID is nil", d.Id()),
+				})
+				return diags
+			}
+			idInterface, ok := v.(map[string]interface{})["id"]
+			if !ok {
+				diags = append(diags, diag.Diagnostic{
+					Severity: diag.Error,
+					Summary:  "Network ID is missing",
+					Detail:   fmt.Sprintf("service (ID: %s): Network ID is missing", d.Id()),
+				})
+				return diags
+			}
+			idFloat, ok := idInterface.(float64)
+			if !ok {
+				diags = append(diags, diag.Diagnostic{
+					Severity: diag.Error,
+					Summary:  "Failed to convert network ID to float64",
+					Detail:   fmt.Sprintf("service (ID: %s): Failed to convert network ID to float64", d.Id()),
+				})
+				return diags
+			}
+			s := strconv.Itoa(int(idFloat))
 			networkID, err := strconv.ParseInt(s, 10, 0)
 			if err != nil {
 				diags = append(diags, diag.Diagnostic{
@@ -328,6 +354,7 @@ func resourceOpennebulaServiceRead(ctx context.Context, d *schema.ResourceData, 
 		}
 	}
 	d.Set("networks", networks)
+
 
 	// Retrieve roles
 	var roles []map[string]interface{}


### PR DESCRIPTION
Refactored network ID retrieval logic to include checks for nil values and to ensure that the 'id' field is of type float64 before conversion. This prevents a panic caused by improper type assertion and ensures robust error handling in case of missing or invalid network IDs.

<!--- Please keep this note for the community --->

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

<!--- Please leave a helpful description of the PR here. --->

### References

#000

### New or Affected Resource(s)

<!--- Please list the new or affected resources and data sources. --->

- opennebula_XXXXX

### Checklist

<!--- Please check you didn't forgot a step to help us merging this PR. --->

- [ ] I have created an issue and I have mentioned it in `References`
- [ ] My code follows the style guidelines of this project (use `go fmt`)
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the unit tests and they pass succesfuly
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation (if needed)
- [ ] I have updated the changelog file
