### PR TITLE
only set randompasswd in graphics template if it's true

### DIFF
--- a/opennebula/shared_schemas.go
+++ b/opennebula/shared_schemas.go
@@ -641,23 +641,23 @@ func addGraphic(tpl *vm.Template, graphics []interface{}) {
 				}
 
 				switch k {
-					case "listen":
-						tpl.AddIOGraphic(vmk.Listen, v.(string))
-					case "type":
-						tpl.AddIOGraphic(vmk.GraphicType, v.(string))
-					case "port":
-						tpl.AddIOGraphic(vmk.Port, v.(string))
-					case "keymap":
-						tpl.AddIOGraphic(vmk.Keymap, v.(string))
-					case "passwd":
-						tpl.AddIOGraphic(vmk.Passwd, v.(string))
-					case "random_passwd":
-						// only set random_passwd if it's set to true -- older OpenNebula versions will consider any
-						// non-zero string as a yes
-						if v.(bool) {
-							tpl.AddIOGraphic(vmk.RandomPassword, "YES")
-						}
-				}   
+				case "listen":
+					tpl.AddIOGraphic(vmk.Listen, v.(string))
+				case "type":
+					tpl.AddIOGraphic(vmk.GraphicType, v.(string))
+				case "port":
+					tpl.AddIOGraphic(vmk.Port, v.(string))
+				case "keymap":
+					tpl.AddIOGraphic(vmk.Keymap, v.(string))
+				case "passwd":
+					tpl.AddIOGraphic(vmk.Passwd, v.(string))
+				case "random_passwd":
+					// only set random_passwd if it's set to true -- older OpenNebula versions will consider any
+					// non-zero string as a yes
+					if v.(bool) {
+						tpl.AddIOGraphic(vmk.RandomPassword, "YES")
+					}
+				}
 			}
 		}
 	}

--- a/opennebula/shared_schemas.go
+++ b/opennebula/shared_schemas.go
@@ -640,24 +640,24 @@ func addGraphic(tpl *vm.Template, graphics []interface{}) {
 					continue
 				}
 
-     	  switch k {
-			  case "listen":
-				  tpl.AddIOGraphic(vmk.Listen, v.(string))
-			  case "type":
-				  tpl.AddIOGraphic(vmk.GraphicType, v.(string))
-			  case "port":
-				  tpl.AddIOGraphic(vmk.Port, v.(string))
-			  case "keymap":
-				  tpl.AddIOGraphic(vmk.Keymap, v.(string))
-			  case "passwd":
-				  tpl.AddIOGraphic(vmk.Passwd, v.(string))
-			  case "random_passwd":
-				  // only set random_passwd if it's set to true -- older OpenNebula versions will consider any
-				  // non-zero string as a yes
-				  if v.(bool) {
-					  tpl.AddIOGraphic(vmk.RandomPassword, "YES")
-				  }
-			  }   
+				switch k {
+					case "listen":
+						tpl.AddIOGraphic(vmk.Listen, v.(string))
+					case "type":
+						tpl.AddIOGraphic(vmk.GraphicType, v.(string))
+					case "port":
+						tpl.AddIOGraphic(vmk.Port, v.(string))
+					case "keymap":
+						tpl.AddIOGraphic(vmk.Keymap, v.(string))
+					case "passwd":
+						tpl.AddIOGraphic(vmk.Passwd, v.(string))
+					case "random_passwd":
+						// only set random_passwd if it's set to true -- older OpenNebula versions will consider any
+						// non-zero string as a yes
+						if v.(bool) {
+							tpl.AddIOGraphic(vmk.RandomPassword, "YES")
+						}
+				}   
 			}
 		}
 	}

--- a/opennebula/shared_schemas.go
+++ b/opennebula/shared_schemas.go
@@ -632,8 +632,11 @@ func addGraphic(tpl *vm.Template, graphics []interface{}) {
 			case "passwd":
 				tpl.AddIOGraphic(vmk.Passwd, v.(string))
 			case "random_passwd":
-				// Convert bool to string
-				tpl.AddIOGraphic(vmk.RandomPassword, map[bool]string{true: "YES", false: "NO"}[v.(bool)])
+				// only set random_passwd if it's set to true -- older OpenNebula versions will consider any
+				// non-zero string as a yes
+				if v.(bool) {
+					tpl.AddIOGraphic(vmk.RandomPassword, "YES")
+				}
 			}
 
 		}


### PR DESCRIPTION


<!--- Please keep this note for the community --->

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

older OpenNebula versions (like 5.12) interpret the `RANDOM_PASSWORD` as truthy if its value is not empty and therefore try to generate a password, which when using VNC will be too long and not truncated due to another bug that's already been fixed in the latest release.

(yes, I know, we should really update our setup ...)

### References


### New or Affected Resource(s)

<!--- Please list the new or affected resources and data sources. --->

- opennebula_template

### Checklist

<!--- Please check you didn't forgot a step to help us merging this PR. --->

- [ ] I have created an issue and I have mentioned it in `References`
- [x] My code follows the style guidelines of this project (use `go fmt`)
- [x] My changes generate no new warnings or errors
- [x] I have updated the unit tests and they pass succesfuly
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation (if needed)
- [ ] I have updated the changelog file
