### PR TITLE
B #537: Make Virtual Router's instances re-contextable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ ENHANCEMENTS:
 
 * resources/opennebula_template: enable disk and nic update (#491)
 
+BUG FIXES:
+
+* resources/opennebula_virtual_router_instance: fix re-contextualization (#537)
+
 # 1.4.0 (January 22nd, 2024)
 
 FEATURES:

--- a/opennebula/resource_opennebula_virtual_router_test.go
+++ b/opennebula/resource_opennebula_virtual_router_test.go
@@ -91,6 +91,22 @@ func TestAccVirtualRouter(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccVirtualRouterContextUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("opennebula_virtual_router_instance.test2", "context.update_test", "123"),
+					resource.TestCheckResourceAttrSet("opennebula_virtual_router.test", "uid"),
+					resource.TestCheckResourceAttrSet("opennebula_virtual_router.test", "gid"),
+					resource.TestCheckResourceAttrSet("opennebula_virtual_router.test", "uname"),
+					resource.TestCheckResourceAttrSet("opennebula_virtual_router.test", "gname"),
+					testAccCheckVirtualRouterPermissions(&shared.Permissions{
+						OwnerU: 1,
+						OwnerM: 1,
+						GroupU: 1,
+						OtherM: 1,
+					}, "testacc-vr"),
+				),
+			},
+			{
 				Config: testAccVirtualRouterAddNICs,
 				Check: resource.ComposeTestCheckFunc(
 					// Virtual router
@@ -352,6 +368,46 @@ resource "opennebula_virtual_router_instance" "test2" {
 	cpu = 0.1
 
 	virtual_router_id = opennebula_virtual_router.test.id
+}
+
+resource "opennebula_virtual_router" "test" {
+  name = "testacc-vr"
+  permissions = "642"
+  group = "oneadmin"
+
+  instance_template_id = opennebula_virtual_router_instance_template.test.id
+
+  tags = {
+    customer = "1"
+  }
+}
+`
+
+var testAccVirtualRouterContextUpdate = testAccVirtualRouterMachineTemplate + `
+
+resource "opennebula_virtual_router_instance" "test" {
+	name        = "testacc-vr-virtual-machine"
+	group       = "oneadmin"
+	permissions = "642"
+	memory = 128
+	cpu = 0.1
+
+	virtual_router_id = opennebula_virtual_router.test.id
+}
+
+
+resource "opennebula_virtual_router_instance" "test2" {
+	name        = "testacc-vr-virtual-machine-2"
+	group       = "oneadmin"
+	permissions = "642"
+	memory = 128
+	cpu = 0.1
+
+	virtual_router_id = opennebula_virtual_router.test.id
+
+	context = {
+	  update_test = "123"
+	}
 }
 
 resource "opennebula_virtual_router" "test" {


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

<!--- Please leave a helpful description of the PR here. --->

This is a fix that enables Virtual Router instances to be updated/re-contexted.

### References

#537 

### New or Affected Resource(s)

<!--- Please list the new or affected resources and data sources. --->

- opennebula_virtual_router_instance

### Checklist

<!--- Please check you didn't forgot a step to help us merging this PR. --->

- [x] I have created an issue and I have mentioned it in `References`
- [x] My code follows the style guidelines of this project (use `go fmt`)
- [x] My changes generate no new warnings or errors
- [x] I have updated the unit tests and they pass succesfuly
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation (if needed)
- [x] I have updated the changelog file
