### PR TITLE
Fix trailing space in CEPH_HOST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ ENHANCEMENTS:
 BUG FIXES:
 
 * resources/opennebula_virtual_router_instance: fix re-contextualization (#537)
+* resources/opennebula_datastore: fix trailing space in CEPH_HOST (#543)
 
 # 1.4.0 (January 22nd, 2024)
 

--- a/opennebula/resource_opennebula_datastore.go
+++ b/opennebula/resource_opennebula_datastore.go
@@ -416,9 +416,11 @@ func addCephAttributes(attrs map[string]interface{}, tpl *datastore.Template) {
 		hosts := hostsIf.(*schema.Set).List()
 
 		var hostsStr strings.Builder
-		for _, host := range hosts {
+		for i, host := range hosts {
 			hostsStr.WriteString(host.(string))
-			hostsStr.WriteString(" ")
+			if i < len(hosts)-1 {
+				hostsStr.WriteString(" ")
+			}
 		}
 		tpl.Add("CEPH_HOST", hostsStr.String())
 	}


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

Fixes trailing space in CEPH_HOST parameter.

### References

#543 

### New or Affected Resource(s)

<!--- Please list the new or affected resources and data sources. --->

- opennebula_datastore

### Checklist

<!--- Please check you didn't forgot a step to help us merging this PR. --->

- [x] I have created an issue and I have mentioned it in `References`
- [x] My code follows the style guidelines of this project (use `go fmt`)
- [x] My changes generate no new warnings or errors
- [ ] I have updated the unit tests and they pass succesfuly
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation (if needed)
- [x] I have updated the changelog file
