### PR TITLE
F #547: Add floating_only VR nic IP allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ FEATURES:
 
 * resources/opennebula_virtual_network: allow to modify the user owning the resource (#529)
 * resources/opennebula_virtual_machine: add nil checks before type casting (#530)
+* resources/opennebula_virtual_router_nic: add floating_only nic argument (#547)
 
 ENHANCEMENTS:
 

--- a/opennebula/resource_opennebula_virtual_router_nic.go
+++ b/opennebula/resource_opennebula_virtual_router_nic.go
@@ -81,6 +81,12 @@ func resourceOpennebulaVirtualRouterNIC() *schema.Resource {
 				Default:  false,
 				ForceNew: true,
 			},
+			"floating_only": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -123,6 +129,11 @@ func resourceOpennebulaVirtualRouterNICCreate(ctx context.Context, d *schema.Res
 	if v, ok := d.GetOk("floating_ip"); ok {
 		if v.(bool) {
 			nicTpl.Add("FLOATING_IP", "YES")
+		}
+	}
+	if v, ok := d.GetOk("floating_only"); ok {
+		if v.(bool) {
+			nicTpl.Add("FLOATING_ONLY", "YES")
 		}
 	}
 
@@ -197,6 +208,7 @@ func resourceOpennebulaVirtualRouterNICRead(ctx context.Context, d *schema.Resou
 	}
 
 	floatingIP, _ := nic.GetStr("FLOATING_IP")
+	floatingOnly, _ := nic.GetStr("FLOATING_ONLY")
 
 	d.Set("network_id", networkID)
 	d.Set("virtual_router_id", vr.ID)
@@ -206,6 +218,7 @@ func resourceOpennebulaVirtualRouterNICRead(ctx context.Context, d *schema.Resou
 	d.Set("virtio_queues", virtioQueues)
 	d.Set("security_groups", sg)
 	d.Set("floating_ip", strings.ToUpper(floatingIP) == "YES")
+	d.Set("floating_only", strings.ToUpper(floatingOnly) == "YES")
 
 	return nil
 }

--- a/opennebula/resource_opennebula_virtual_router_test.go
+++ b/opennebula/resource_opennebula_virtual_router_test.go
@@ -104,7 +104,9 @@ func TestAccVirtualRouter(t *testing.T) {
 					resource.TestCheckResourceAttrSet("opennebula_virtual_router_nic.nic1", "network_id"),
 					resource.TestCheckResourceAttrSet("opennebula_virtual_router_nic.nic2", "network_id"),
 					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic1", "floating_ip", "true"),
+					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic1", "floating_only", "true"),
 					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic2", "floating_ip", "false"),
+					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic2", "floating_only", "false"),
 					testAccCheckVirtualRouterPermissions(&shared.Permissions{
 						OwnerU: 1,
 						OwnerM: 1,
@@ -127,7 +129,9 @@ func TestAccVirtualRouter(t *testing.T) {
 					resource.TestCheckResourceAttrSet("opennebula_virtual_router_nic.nic1", "network_id"),
 					resource.TestCheckResourceAttrSet("opennebula_virtual_router_nic.nic2", "network_id"),
 					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic1", "floating_ip", "false"),
+					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic1", "floating_only", "false"),
 					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic2", "floating_ip", "false"),
+					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic2", "floating_only", "false"),
 					testAccCheckVirtualRouterPermissions(&shared.Permissions{
 						OwnerU: 1,
 						OwnerM: 1,
@@ -409,6 +413,7 @@ resource "opennebula_virtual_router_nic" "nic2" {
 
 resource "opennebula_virtual_router_nic" "nic1" {
   floating_ip       = true
+  floating_only     = true
   virtual_router_id = opennebula_virtual_router.test.id
   network_id        = opennebula_virtual_network.network1.id
 }

--- a/website/docs/r/virtual_router_nic.markdown
+++ b/website/docs/r/virtual_router_nic.markdown
@@ -91,6 +91,7 @@ resource "opennebula_virtual_network" "example" {
 
 resource "opennebula_virtual_router_nic" "example1" {
   floating_ip       = true
+  floating_only     = true
   virtual_router_id = opennebula_virtual_router.example.id
   network_id        = opennebula_virtual_network.example.id
 }
@@ -112,6 +113,7 @@ The following arguments are supported:
 * `physical_device` - (Optional) Physical device hosting the virtual network.
 * `security_groups` - (Optional) List of security group IDs to use on the virtual network.
 * `floating_ip` - (Optional) Allocate floating IP for the NIC. Defaults to `false`.
+* `floating_only` - (Optional) Do not allocate IP for the NIC. Defaults to `false`.
 
 ## Attribute Reference
 
@@ -123,6 +125,7 @@ The following attribute are exported:
 * `physical_device` - Physical device hosting the virtual network.
 * `security_groups` - List of security group IDs to use on the virtual network.
 * `floating_ip` - Allocate floating IP for the NIC. Defaults to `false`.
+* `floating_only` - (Optional) Do not allocate IP for the NIC. Defaults to `false`.
 
 ## Import
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

<!--- Please leave a helpful description of the PR here. --->

Since https://github.com/OpenNebula/one-ee/commit/0a7a03e098d4da6db5f057cec29daf56028b83b6 VR instances support instance deployment without NIC-dedicated IPs if the VIP is defined and is marked floating_only. This PR enables that feature in the Provider.

### References

Close #547 

### New or Affected Resource(s)

<!--- Please list the new or affected resources and data sources. --->

- opennebula_virtual_router_nic

### Checklist

<!--- Please check you didn't forgot a step to help us merging this PR. --->

- [x] I have created an issue and I have mentioned it in `References`
- [x] My code follows the style guidelines of this project (use `go fmt`)
- [x] My changes generate no new warnings or errors
- [x] I have updated the unit tests and they pass succesfuly
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation (if needed)
- [x] I have updated the changelog file
