### PR TITLE
Allow Updates to `template` Attribute in `opennebula_service_template` Resource Without Forcing New Resource

### DIFF
--- a/opennebula/resource_opennebula_service_template.go
+++ b/opennebula/resource_opennebula_service_template.go
@@ -382,7 +382,7 @@ func resourceOpennebulaServiceTemplateUpdate(ctx context.Context, d *schema.Reso
 		stemplate.Template = newSTemplate.Template
 
 		// Apply the changes
-		err = stc.Update(stemplate,true)
+		err = stc.Update(stemplate, true)
 		if err != nil {
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,

--- a/opennebula/resource_opennebula_service_template.go
+++ b/opennebula/resource_opennebula_service_template.go
@@ -37,7 +37,7 @@ func resourceOpennebulaServiceTemplate() *schema.Resource {
 			"template": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
+				ForceNew:    false,
 				Description: "Service Template body in json format",
 				// Check JSON structure diffs, not binary diffs
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
@@ -361,6 +361,38 @@ func resourceOpennebulaServiceTemplateUpdate(ctx context.Context, d *schema.Reso
 			Detail:   fmt.Sprintf("service template (ID: %s): %s", d.Id(), err),
 		})
 		return diags
+	}
+
+	if d.HasChange("template") {
+		newTemplate := d.Get("template").(string)
+
+		// Unmarshal the new template
+		newSTemplate := &srv_tmpl.ServiceTemplate{}
+		err := json.Unmarshal([]byte(newTemplate), newSTemplate)
+		if err != nil {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  "Failed to parse the new template",
+				Detail:   err.Error(),
+			})
+			return diags
+		}
+
+		// Update the template
+		stemplate.Template = newSTemplate.Template
+
+		// Apply the changes
+		err = stc.Update(stemplate,true)
+		if err != nil {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  "Failed to update the service template",
+				Detail:   err.Error(),
+			})
+			return diags
+		}
+
+		log.Printf("[INFO] Successfully updated the template for service template ID %x\n", stemplate.ID)
 	}
 
 	if d.HasChange("name") {


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

This pull request modifies the `opennebula_service_template` resource to allow updates to the `template` attribute without forcing the resource to be recreated. The following changes were made:

- Set `ForceNew` to `false` for the `template` attribute.
- Added logic to handle updates to the `template` attribute in the `resourceOpennebulaServiceTemplateUpdate` function.

These changes enable updating the `template` attribute and applying changes without recreating the entire resource.


### New or Affected Resource(s)

- opennebula_service_template

### Checklist

- [ ] I have created an issue and I have mentioned it in `References`
- [ ] My code follows the style guidelines of this project (use `go fmt`)
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the unit tests and they pass successfully
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation (if needed)
- [ ] I have updated the changelog file
