### PR TITLE
F #548: Add method, gateway, dns arguments for nics

### DIFF
--- a/.github/scripts/oned.sh
+++ b/.github/scripts/oned.sh
@@ -28,7 +28,9 @@ sed '/DATASTORE_MAD/,+3 d' -i /etc/one/oned.conf
 echo 'IM_MAD = [ NAME="dummy", SUNSTONE_NAME="Dummy", EXECUTABLE="one_im_sh", ARGUMENTS="-r 3 -t 15 -w 90 dummy", THREADS=0]' >> /etc/one/monitord.conf
 echo 'VM_MAD = [ NAME="dummy", SUNSTONE_NAME="Testing", EXECUTABLE="one_vmm_dummy",TYPE="xml" ]' >> /etc/one/oned.conf
 echo 'DATASTORE_MAD = [ EXECUTABLE = "one_datastore", ARGUMENTS  = "-t 15 -d dummy,fs,lvm,ceph,dev,iscsi_libvirt,vcenter -s dummy,shared,ssh,ceph,fs_lvm,fs_lvm_ssh,qcow2,vcenter"]' >> /etc/one/oned.conf
-
+echo 'INHERIT_VNET_ATTR = "DNS"' >> /etc/one/oned.conf
+echo 'INHERIT_VNET_ATTR = "GATEWAY"' >> /etc/one/oned.conf
+echo 'INHERIT_VNET_ATTR = "METHOD"' >> /etc/one/oned.conf
 
 # start oned
 sudo systemctl start opennebula

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ FEATURES:
 * resources/opennebula_virtual_network: allow to modify the user owning the resource (#529)
 * resources/opennebula_virtual_machine: add nil checks before type casting (#530)
 * resources/opennebula_virtual_router_nic: add floating_only nic argument (#547)
+* resources/opennebula_virtual_machine: add method, gateway, dns arguments for nics (#548)
 
 ENHANCEMENTS:
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/OpenNebula/terraform-provider-opennebula
 go 1.18
 
 require (
-	github.com/OpenNebula/one/src/oca/go/src/goca v0.0.0-20230912160253-4673721a21ca
+	github.com/OpenNebula/one/src/oca/go/src/goca v0.0.0-20240528115224-c53e48565a10
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/cFDk=
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
-github.com/OpenNebula/one/src/oca/go/src/goca v0.0.0-20230912160253-4673721a21ca h1:0d7BySuGPBL+/7kVTW/29kJJhPLCFW0w4nLBaHI14jc=
-github.com/OpenNebula/one/src/oca/go/src/goca v0.0.0-20230912160253-4673721a21ca/go.mod h1:dvAwZi1Aol7eu6BENzHtl8ztGBkacB9t/fJj+fYk+Xg=
+github.com/OpenNebula/one/src/oca/go/src/goca v0.0.0-20240528115224-c53e48565a10 h1:g++kihIwzRFwxAV6fQzvwsEP6/l9ej8G/tixWaNBc1M=
+github.com/OpenNebula/one/src/oca/go/src/goca v0.0.0-20240528115224-c53e48565a10/go.mod h1:dvAwZi1Aol7eu6BENzHtl8ztGBkacB9t/fJj+fYk+Xg=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C67SkzkDfmQuVln04ygHj3vjZfd9FL+GmQQ=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=

--- a/opennebula/resource_opennebula_virtual_machine.go
+++ b/opennebula/resource_opennebula_virtual_machine.go
@@ -104,6 +104,18 @@ func nicComputedVMFields() map[string]*schema.Schema {
 				Type: schema.TypeInt,
 			},
 		},
+		"computed_method": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"computed_gateway": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"computed_dns": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
 	}
 
 }
@@ -876,6 +888,10 @@ func flattenNICComputed(nic shared.NIC, ignoreSGIDs []int) map[string]interface{
 		sg = append(sg, int(sgInt))
 	}
 
+	method, _ := nic.Get(shared.Method)
+	gateway, _ := nic.Get(shared.Gateway)
+	dns, _ := nic.Get(shared.DNS)
+
 	return map[string]interface{}{
 		"nic_id":                   nicID,
 		"network":                  network,
@@ -885,6 +901,9 @@ func flattenNICComputed(nic shared.NIC, ignoreSGIDs []int) map[string]interface{
 		"computed_model":           model,
 		"computed_virtio_queues":   virtioQueues,
 		"computed_security_groups": sg,
+		"computed_method":          method,
+		"computed_gateway":         gateway,
+		"computed_dns":             dns,
 	}
 }
 
@@ -909,6 +928,15 @@ func flattenVMNICComputed(NICConfig map[string]interface{}, NIC shared.NIC) map[
 	}
 	if len(NICConfig["security_groups"].([]interface{})) > 0 {
 		NICMap["security_groups"] = NICMap["computed_security_groups"]
+	}
+	if len(NICConfig["method"].(string)) > 0 {
+		NICMap["method"] = NICMap["computed_method"]
+	}
+	if len(NICConfig["gateway"].(string)) > 0 {
+		NICMap["gateway"] = NICMap["computed_gateway"]
+	}
+	if len(NICConfig["dns"].(string)) > 0 {
+		NICMap["dns"] = NICMap["computed_dns"]
 	}
 
 	networkMode, err := NIC.Get(shared.NetworkMode)
@@ -1000,11 +1028,18 @@ func matchNIC(NICConfig map[string]interface{}, NIC shared.NIC) bool {
 
 	}
 
+	method, _ := NIC.Get(shared.Method)
+	gateway, _ := NIC.Get(shared.Gateway)
+	dns, _ := NIC.Get(shared.DNS)
+
 	return emptyOrEqual(NICConfig["ip"], ip) &&
 		emptyOrEqual(NICConfig["mac"], mac) &&
 		emptyOrEqual(NICConfig["physical_device"], physicalDevice) &&
 		emptyOrEqual(NICConfig["model"], model) &&
 		emptyOrEqual(NICConfig["virtio_queues"], virtioQueues) &&
+		emptyOrEqual(NICConfig["method"], method) &&
+		emptyOrEqual(NICConfig["gateway"], gateway) &&
+		emptyOrEqual(NICConfig["dns"], dns) &&
 		emptyOrEqual(NICConfig["sched_requirements"], schedRequirements) &&
 		emptyOrEqual(NICConfig["sched_rank"], schedRank) &&
 		(NICConfig["network_mode_auto"].(bool) == false || networkMode == "auto")
@@ -1036,11 +1071,18 @@ func matchNICComputed(NICConfig map[string]interface{}, NIC shared.NIC) bool {
 		}
 	}
 
+	method, _ := NIC.Get(shared.Method)
+	gateway, _ := NIC.Get(shared.Gateway)
+	dns, _ := NIC.Get(shared.DNS)
+
 	return ip == NICConfig["computed_ip"].(string) &&
 		mac == NICConfig["computed_mac"].(string) &&
 		physicalDevice == NICConfig["computed_physical_device"].(string) &&
 		model == NICConfig["computed_model"].(string) &&
-		virtioQueues == NICConfig["computed_virtio_queues"].(string)
+		virtioQueues == NICConfig["computed_virtio_queues"].(string) &&
+		method == NICConfig["computed_method"].(string) &&
+		gateway == NICConfig["computed_gateway"].(string) &&
+		dns == NICConfig["computed_dns"].(string)
 }
 
 // flattenVMNIC is similar to flattenNIC but deal with computed_* attributes
@@ -1900,6 +1942,9 @@ func updateNIC(ctx context.Context, d *schema.ResourceData, meta interface{}) er
 		"model",
 		"virtio_queues",
 		"physical_device",
+		"method",
+		"gateway",
+		"dns",
 		"network_mode_auto",
 		"sched_requirements",
 		"sched_rank",

--- a/opennebula/resource_opennebula_virtual_machine_nic_test.go
+++ b/opennebula/resource_opennebula_virtual_machine_nic_test.go
@@ -52,7 +52,21 @@ func TestAccVirtualMachineNICUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "name", "test-virtual_machine"),
 					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "nic.#", "2"),
 					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "nic.0.computed_ip", "172.16.100.131"),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "nic.0.computed_gateway", "172.16.100.1"),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "nic.0.computed_dns", "8.8.8.8"),
 					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "nic.1.computed_ip", "172.16.100.112"),
+				),
+			},
+			{
+				Config: testAccVirtualMachineTemplateConfigNICExtraUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "name", "test-virtual_machine"),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "nic.#", "2"),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "nic.0.computed_ip", "172.16.100.131"),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "nic.0.computed_gateway", "172.16.100.254"),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "nic.0.computed_dns", "1.1.1.1"),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "nic.1.computed_ip", "172.16.100.112"),
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "nic.1.computed_method", "skip"),
 				),
 			},
 			{
@@ -210,6 +224,8 @@ resource "opennebula_virtual_network" "network1" {
 	group = "oneadmin"
 	security_groups = [0]
 	cluster_ids = [0]
+	gateway = "172.16.100.1"
+	dns = "8.8.8.8"
   }
 
   resource "opennebula_virtual_network" "network2" {
@@ -321,23 +337,23 @@ var testAccVirtualMachineTemplateConfigNICUpdate = testNICVNetResources + `
 	  permissions = "642"
 	  memory = 128
 	  cpu = 0.1
-	
+
 	  context = {
 		NETWORK  = "YES"
 		SET_HOSTNAME = "$NAME"
 	  }
-	
+
 	  graphics {
 		type   = "VNC"
 		listen = "0.0.0.0"
 		keymap = "en-us"
 	  }
-	
+
 	  os {
 		arch = "x86_64"
 		boot = ""
 	  }
-	
+
 	  tags = {
 		env = "prod"
 		customer = "test"
@@ -352,7 +368,7 @@ var testAccVirtualMachineTemplateConfigNICUpdate = testNICVNetResources + `
 		network_id = opennebula_virtual_network.network2.id
 		ip = "172.16.100.111"
 	  }
-	
+
 	  timeout = 5
 }
 `
@@ -365,23 +381,23 @@ var testAccVirtualMachineTemplateConfigNICIPUpdate = testNICVNetResources + `
 	  permissions = "642"
 	  memory = 128
 	  cpu = 0.1
-	
+
 	  context = {
 		NETWORK  = "YES"
 		SET_HOSTNAME = "$NAME"
 	  }
-	
+
 	  graphics {
 		type   = "VNC"
 		listen = "0.0.0.0"
 		keymap = "en-us"
 	  }
-	
+
 	  os {
 		arch = "x86_64"
 		boot = ""
 	  }
-	
+
 	  tags = {
 		env = "prod"
 		customer = "test"
@@ -397,6 +413,52 @@ var testAccVirtualMachineTemplateConfigNICIPUpdate = testNICVNetResources + `
 		ip = "172.16.100.112"
 	  }
 
+	  timeout = 5
+}
+`
+
+var testAccVirtualMachineTemplateConfigNICExtraUpdate = testNICVNetResources + `
+
+  resource "opennebula_virtual_machine" "test" {
+	  name        = "test-virtual_machine"
+	  group       = "oneadmin"
+	  permissions = "642"
+	  memory = 128
+	  cpu = 0.1
+
+	  context = {
+		NETWORK  = "YES"
+		SET_HOSTNAME = "$NAME"
+	  }
+
+	  graphics {
+		type   = "VNC"
+		listen = "0.0.0.0"
+		keymap = "en-us"
+	  }
+
+	  os {
+		arch = "x86_64"
+		boot = ""
+	  }
+
+	  tags = {
+		env = "prod"
+		customer = "test"
+	  }
+
+	  nic {
+		network_id = opennebula_virtual_network.network1.id
+		ip = "172.16.100.131"
+		security_groups = [opennebula_security_group.mysecgroup.id]
+		gateway = "172.16.100.254"
+		dns = "1.1.1.1"
+	  }
+	  nic {
+		network_id = opennebula_virtual_network.network2.id
+		ip = "172.16.100.112"
+		method = "skip" # IP is assigned normally in oned, but then one-context ignores it.
+	  }
 
 	  timeout = 5
 }

--- a/opennebula/shared_schemas.go
+++ b/opennebula/shared_schemas.go
@@ -225,6 +225,18 @@ func nicFields() map[string]*schema.Schema {
 				Type: schema.TypeInt,
 			},
 		},
+		"method": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"gateway": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"dns": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
 		"network_mode_auto": {
 			Type:     schema.TypeBool,
 			Optional: true,
@@ -584,6 +596,12 @@ func makeNICVector(nicConfig map[string]interface{}) *shared.NIC {
 		case "security_groups":
 			nicSecGroups := ArrayToString(v.([]interface{}), ",")
 			nic.Add(shared.SecurityGroups, nicSecGroups)
+		case "method":
+			nic.Add(shared.Method, v.(string))
+		case "gateway":
+			nic.Add(shared.Gateway, v.(string))
+		case "dns":
+			nic.Add(shared.DNS, v.(string))
 		case "network_mode_auto":
 			if v.(bool) {
 				nic.Add(shared.NetworkMode, "auto")
@@ -592,7 +610,6 @@ func makeNICVector(nicConfig map[string]interface{}) *shared.NIC {
 			nic.Add(shared.SchedRequirements, v.(string))
 		case "sched_rank":
 			nic.Add(shared.SchedRank, v.(string))
-
 		}
 	}
 
@@ -857,6 +874,10 @@ func flattenNIC(nic shared.NIC) map[string]interface{} {
 		}
 	}
 
+	method, _ := nic.Get(shared.Method)
+	gateway, _ := nic.Get(shared.Gateway)
+	dns, _ := nic.Get(shared.DNS)
+
 	return map[string]interface{}{
 		"ip":                 ip,
 		"mac":                mac,
@@ -866,6 +887,9 @@ func flattenNIC(nic shared.NIC) map[string]interface{} {
 		"model":              model,
 		"virtio_queues":      virtioQueues,
 		"security_groups":    sg,
+		"method":             method,
+		"gateway":            gateway,
+		"dns":                dns,
 		"network_mode_auto":  networkModeBool,
 		"sched_requirements": schedReqs,
 		"sched_rank":         schedRank,

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -57,6 +57,9 @@ resource "opennebula_virtual_machine" "example" {
     model           = "virtio"
     network_id      = var.vnetid
     security_groups = [opennebula_security_group.example.id]
+
+    # NOTE: To make this work properly ensure /etc/one/oned.conf contains: INHERIT_VNET_ATTR="DNS"
+    dns = "1.1.1.1"
   }
 
   vmgroup {
@@ -153,6 +156,9 @@ A disk update will be triggered in adding or removing a `disk` section, or by a 
 * `virtio_queues` - (Optional) Virtio multi-queue size. Only if `model` is `virtio`.
 * `physical_device` - (Optional) Physical device hosting the virtual network.
 * `security_groups` - (Optional) List of security group IDs to use on the virtual network.
+* `method` - (Optional) Method of obtaining IP addresses (empty or `static`, `dhcp`, `skip`).
+* `gateway` - (Optional) Default gateway set for the NIC.
+* `dns` - (Optional) DNS server set for the NIC. **Please make sure `INHERIT_VNET_ATTR="DNS"` is added to `/etc/one/oned.conf`.**
 * `network_mode_auto` - (Optional) A boolean letting the scheduler pick the Virtual Networks the VM NICs will be attached to. Can only be used at VM creation.
 * `sched_requirements` - (Optional) A boolean expression to select virtual networks (evaluates to true) to attach the NIC,  when `network_mode_auto` is true. Can only be used at VM creation.
 * `sched_rank` - (Optional) Arithmetic expression to sort the suitable Virtual Networks for this NIC, when `network_mode_auto` is true. Can only be used at VM creation.
@@ -211,6 +217,9 @@ The following attribute are exported:
 * `computed_virtio_queues` - Virtio multi-queue size.
 * `computed_physical_device` - Physical device hosting the virtual network.
 * `computed_security_groups` - List of security group IDs to use on the virtual.
+* `computed_method` - Method of obtaining IP addresses (empty or `static`, `dhcp`, `skip`).
+* `computed_gateway` - Default gateway set for the NIC.
+* `computed_dns` - DNS server set for the NIC.
 
 ### Template disk
 
@@ -230,6 +239,9 @@ The following attribute are exported:
 * `computed_virtio_queues` - Virtio multi-queue size.
 * `computed_physical_device` - Physical device hosting the virtual network.
 * `computed_security_groups` - List of security group IDs to use on the virtual.
+* `computed_method` - Method of obtaining IP addresses (empty or `static`, `dhcp`, `skip`).
+* `computed_gateway` - Default gateway set for the NIC.
+* `computed_dns` - DNS server set for the NIC.
 
 ### Disk
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

<!--- Please leave a helpful description of the PR here. --->

VM/Template NIC vectors inherit `method`, `gateway` and `dns` arguments from VNETs and ARs (look [here](https://docs.opennebula.io/6.8/management_and_operations/references/vnet_template.html#contextualization-attributes)). Those are defnitely useful good-to-have things, we add them to the interface in this PR. :slightly_smiling_face: 

### References

#548

### New or Affected Resource(s)

<!--- Please list the new or affected resources and data sources. --->

- opennebula_virtual_machine

### Checklist

<!--- Please check you didn't forgot a step to help us merging this PR. --->

- [x] I have created an issue and I have mentioned it in `References`
- [x] My code follows the style guidelines of this project (use `go fmt`)
- [x] My changes generate no new warnings or errors
- [x] I have updated the unit tests and they pass succesfuly
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation (if needed)
- [x] I have updated the changelog file
