### PR TITLE
B-497: fix vmgroup anti-affinity variable name at read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.4.2 (Unreleased)
+
+BUG FIXES:
+
+* resources/opennebula_vm_group: fix anti affinity reading (#497)
+
 # 1.4.1 (Unreleased)
 
 FEATURES:

--- a/opennebula/resource_opennebula_vm_group.go
+++ b/opennebula/resource_opennebula_vm_group.go
@@ -338,7 +338,7 @@ func flattenVMGroupRoles(d *schema.ResourceData, vmgRoles []vmgroup.Role) error 
 			hostAntiAffString := strings.Split(vmgr.HostAntiAffined, ",")
 			for _, h := range hostAntiAffString {
 				hostAntiAffInt, _ := strconv.ParseInt(h, 10, 0)
-				hAntiAff = append(hAff, int(hostAntiAffInt))
+				hAntiAff = append(hAntiAff, int(hostAntiAffInt))
 			}
 		}
 		roles = append(roles, map[string]interface{}{


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

<!--- Please leave a helpful description of the PR here. --->
An error in the development of the VM group resource lead to an error during read step.

### References

Close #497

### New or Affected Resource(s)

<!--- Please list the new or affected resources and data sources. --->

- opennebula_vm_group

### Checklist

<!--- Please check you didn't forgot a step to help us merging this PR. --->

- [ ] I have created an issue and I have mentioned it in `References`
- [ ] My code follows the style guidelines of this project (use `go fmt`)
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the unit tests and they pass succesfuly
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation (if needed)
- [ ] I have updated the changelog file
