### PR TITLE
B-515: fix ignored vlan_id

### DIFF
--- a/opennebula/resource_opennebula_virtual_network.go
+++ b/opennebula/resource_opennebula_virtual_network.go
@@ -802,15 +802,19 @@ func generateVn(d *schema.ResourceData) (string, error) {
 	tpl.Add(vnk.Name, vnname)
 	tpl.Add(vnk.VNMad, vnmad)
 
-	if mandatoryVLAN(vnmad) {
-		if d.Get("automatic_vlan_id") == true {
-			tpl.Add("AUTOMATIC_VLAN_ID", "YES")
-		} else if vlanid, ok := d.GetOk("vlan_id"); ok {
-			tpl.Add(vnk.VlanID, vlanid.(string))
-		} else {
-			return "", fmt.Errorf("You must specify a 'vlan_id' or set the flag 'automatic_vlan_id'")
-		}
+	vlanSet := false
+	if d.Get("automatic_vlan_id").(bool) {
+		tpl.Add("AUTOMATIC_VLAN_ID", "YES")
+		vlanSet = true
+	} else if vlanid, ok := d.GetOk("vlan_id"); ok {
+		tpl.Add(vnk.VlanID, vlanid.(string))
+		vlanSet = true
 	}
+
+	if mandatoryVLAN(vnmad) && !vlanSet {
+		return "", fmt.Errorf("you must specify a 'vlan_id' or set the flag 'automatic_vlan_id'")
+	}
+
 	if vnbridge, ok := d.GetOk("bridge"); ok {
 		tpl.Add(vnk.Bridge, vnbridge.(string))
 	}


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

<!--- Please leave a helpful description of the PR here. --->

Allow to optionally set a `vlan_id` value for ovswitch
Related older PR #407  

### References

Close #515

### New or Affected Resource(s)

<!--- Please list the new or affected resources and data sources. --->

- opennebula_virtual_network

### Checklist

<!--- Please check you didn't forgot a step to help us merging this PR. --->

- [ ] I have created an issue and I have mentioned it in `References`
- [ ] My code follows the style guidelines of this project (use `go fmt`)
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the unit tests and they pass succesfuly
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation (if needed)
- [ ] I have updated the changelog file
