### PR TITLE
Allow to recreate VMs if in DONE state

### DIFF
--- a/opennebula/resource_opennebula_virtual_machine.go
+++ b/opennebula/resource_opennebula_virtual_machine.go
@@ -526,7 +526,7 @@ func resourceOpennebulaVirtualMachineReadCustom(ctx context.Context, d *schema.R
 
 	// TODO: fix it after 5.10 release
 	// Force the "decrypt" bool to false to keep ONE 5.8 behavior
-	vm, err := vmc.Info(false)
+	vmInfo, err := vmc.Info(false)
 	if err != nil {
 		if NoExists(err) {
 			log.Printf("[WARN] Removing virtual machine %s from state because it no longer exists in", d.Get("name"))
@@ -540,16 +540,21 @@ func resourceOpennebulaVirtualMachineReadCustom(ctx context.Context, d *schema.R
 		})
 		return diags
 	}
-	d.SetId(fmt.Sprintf("%v", vm.ID))
-	d.Set("name", vm.Name)
-	d.Set("uid", vm.UID)
-	d.Set("gid", vm.GID)
-	d.Set("uname", vm.UName)
-	d.Set("gname", vm.GName)
-	d.Set("state", vm.StateRaw)
-	d.Set("lcmstate", vm.LCMStateRaw)
+	d.SetId(fmt.Sprintf("%v", vmInfo.ID))
+	d.Set("name", vmInfo.Name)
+	d.Set("uid", vmInfo.UID)
+	d.Set("gid", vmInfo.GID)
+	d.Set("uname", vmInfo.UName)
+	d.Set("gname", vmInfo.GName)
+	d.Set("state", vmInfo.StateRaw)
+	d.Set("lcmstate", vmInfo.LCMStateRaw)
+	if vm.State(vmInfo.StateRaw) == vm.Done {
+		log.Printf("[WARN] Replacing virtual machine %s (id: %s) because VM is 'Done'; ", d.Get("name"), d.Id())
+		d.SetId("")
+		return nil
+	}
 	//TODO fix this:
-	err = d.Set("permissions", permissionsUnixString(*vm.Permissions))
+	err = d.Set("permissions", permissionsUnixString(*vmInfo.Permissions))
 	if err != nil {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
@@ -560,7 +565,7 @@ func resourceOpennebulaVirtualMachineReadCustom(ctx context.Context, d *schema.R
 	}
 
 	if customVM != nil {
-		customDiags := customVM(ctx, d, vm)
+		customDiags := customVM(ctx, d, vmInfo)
 		if len(customDiags) > 0 {
 			return customDiags
 		}
@@ -571,7 +576,7 @@ func resourceOpennebulaVirtualMachineReadCustom(ctx context.Context, d *schema.R
 	if inheritedVectorsIf != nil {
 		inheritedVectors = inheritedVectorsIf.(map[string]interface{})
 	}
-	err = flattenTemplate(d, inheritedVectors, &vm.Template)
+	err = flattenTemplate(d, inheritedVectors, &vmInfo.Template)
 	if err != nil {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
@@ -587,14 +592,14 @@ func resourceOpennebulaVirtualMachineReadCustom(ctx context.Context, d *schema.R
 		inheritedTags = inheritedTagsIf.(map[string]interface{})
 	}
 
-	flattenDiags := flattenVMUserTemplate(d, meta, inheritedTags, &vm.UserTemplate.Template)
+	flattenDiags := flattenVMUserTemplate(d, meta, inheritedTags, &vmInfo.UserTemplate.Template)
 	for _, diag := range flattenDiags {
 		diag.Detail = fmt.Sprintf("virtual machine (ID: %s): %s", d.Id(), err)
 		diags = append(diags, diag)
 	}
 
-	if vm.LockInfos != nil {
-		d.Set("lock", LockLevelToString(vm.LockInfos.Locked))
+	if vmInfo.LockInfos != nil {
+		d.Set("lock", LockLevelToString(vmInfo.LockInfos.Locked))
 	}
 
 	return diags

--- a/opennebula/resource_opennebula_virtual_machine_test.go
+++ b/opennebula/resource_opennebula_virtual_machine_test.go
@@ -2,10 +2,12 @@ package opennebula
 
 import (
 	"fmt"
+	"github.com/OpenNebula/one/src/oca/go/src/goca/schemas/vm"
 	"os"
 	"reflect"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -313,6 +315,36 @@ func TestAccVirtualMachinePending(t *testing.T) {
 	})
 }
 
+func TestAccVirtualMachineDoneTriggerRecreation(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVirtualMachineDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:             testAccVirtualMachineDone,
+				ExpectNonEmptyPlan: true,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("opennebula_virtual_machine.test", "name", "virtual_machine_done"),
+					testAccTerminateVM("virtual_machine_done"),
+				),
+			},
+			{
+				RefreshState:       true,
+				ExpectNonEmptyPlan: true,
+				Check: resource.ComposeTestCheckFunc(
+					func(state *terraform.State) error {
+						if !state.Empty() && len(state.RootModule().Resources) != 0 {
+							return fmt.Errorf("expected state to be empty")
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
 func TestAccVirtualMachineResize(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -451,6 +483,54 @@ func testAccSetDSdummy() resource.TestCheckFunc {
 			controller.Datastore(1).Update(dstpl.String(), 1)
 		}
 		return nil
+	}
+}
+
+func testAccTerminateVM(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		config := testAccProvider.Meta().(*Configuration)
+		controller := config.Controller
+
+		id, err := controller.VMs().ByName(name)
+		if err != nil {
+			return err
+		}
+
+		err = controller.VM(id).TerminateHard()
+		if err != nil {
+			return err
+		}
+		return waitForVMState(id, vm.Done, time.Minute*5)
+	}
+}
+
+// waitForVMState waits until the VM with vmId has the desiredState.
+// returns an error and a boolean to indicate success.
+// If the timeout is reached or there is an error, success is false
+// success is true if the VM has reached the state within the timeout window
+func waitForVMState(vmId int, desiredState vm.State, timeout time.Duration) error {
+	config := testAccProvider.Meta().(*Configuration)
+	controller := config.Controller
+	interval := time.NewTicker(5 * time.Second)
+	deadline := time.NewTimer(timeout)
+
+	// Ensure ticker and timer are stopped after use
+	defer interval.Stop()
+	defer deadline.Stop()
+
+	for {
+		select {
+		case <-interval.C:
+			info, err := controller.VM(vmId).Info(false)
+			if err != nil {
+				return err
+			}
+			if vm.State(info.StateRaw) == desiredState {
+				return nil
+			}
+		case <-deadline.C:
+			return fmt.Errorf("timeout waiting for vm id '%d' to reach desired state %s\n", vmId, desiredState)
+		}
 	}
 }
 
@@ -842,6 +922,32 @@ resource "opennebula_virtual_machine" "test" {
   memory = 128
   cpu = 0.1
   pending = true
+
+  context = {
+    NETWORK  = "YES"
+    SET_HOSTNAME = "$NAME"
+  }
+
+  graphics {
+    type   = "VNC"
+    listen = "0.0.0.0"
+    keymap = "en-us"
+  }
+
+  os {
+    arch = "x86_64"
+    boot = ""
+  }
+}
+`
+
+var testAccVirtualMachineDone = `
+resource "opennebula_virtual_machine" "test" {
+  name        = "virtual_machine_done"
+  group       = "oneadmin"
+  permissions = "642"
+  memory = 128
+  cpu = 0.1
 
   context = {
     NETWORK  = "YES"

--- a/opennebula/resource_opennebula_virtual_machine_test.go
+++ b/opennebula/resource_opennebula_virtual_machine_test.go
@@ -496,7 +496,7 @@ func testAccTerminateVM(name string) resource.TestCheckFunc {
 			return err
 		}
 
-		err = controller.VM(id).TerminateHard()
+		err = controller.VM(id).Terminate()
 		if err != nil {
 			return err
 		}
@@ -505,9 +505,7 @@ func testAccTerminateVM(name string) resource.TestCheckFunc {
 }
 
 // waitForVMState waits until the VM with vmId has the desiredState.
-// returns an error and a boolean to indicate success.
-// If the timeout is reached or there is an error, success is false
-// success is true if the VM has reached the state within the timeout window
+// returns an error if timeout is reached.
 func waitForVMState(vmId int, desiredState vm.State, timeout time.Duration) error {
 	config := testAccProvider.Meta().(*Configuration)
 	controller := config.Controller


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description
Detect `done` state for VMs and reconcile them via recreation.
Also renames `vm` variable into `vmInfo` to prevent collision with the `github.com/OpenNebula/one/src/oca/go/src/goca/schemas/vm` package import.
 
<!--- Please leave a helpful description of the PR here. --->

### References

Fixes #562

### New or Affected Resource(s)

<!--- Please list the new or affected resources and data sources. --->

- `opennebula_virtual_router_instance`
- `opennebula_virtual_machine`

### Checklist

<!--- Please check you didn't forgot a step to help us merging this PR. --->

- [x] I have created an issue and I have mentioned it in `References`
- [x] My code follows the style guidelines of this project (use `go fmt`)
- [x] My changes generate no new warnings or errors
- [x] I have updated the unit tests and they pass succesfuly
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation (if needed)
- [ ] I have updated the changelog file
