### PR TITLE
Be more forgiving when parsing IDs in service networks_values

### DIFF
--- a/opennebula/helpers.go
+++ b/opennebula/helpers.go
@@ -3,6 +3,7 @@ package opennebula
 import (
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 
 	"github.com/OpenNebula/one/src/oca/go/src/goca/errors"
@@ -142,4 +143,16 @@ func mergeSchemas(schema map[string]*schema.Schema, schemas ...map[string]*schem
 	}
 
 	return schema
+}
+
+func ParseIntFromInterface(i interface{}) (int, error) {
+	switch v := i.(type) {
+	case float64:
+		return int(v), nil
+	case string:
+		if r, err := strconv.ParseInt(v, 10, 32); err == nil {
+			return int(r), nil
+		}
+	}
+	return -1, fmt.Errorf("Does not look like a number")
 }

--- a/opennebula/resource_opennebula_service.go
+++ b/opennebula/resource_opennebula_service.go
@@ -124,7 +124,7 @@ func resourceOpennebulaService() *schema.Resource {
 			"roles": {
 				Type:        schema.TypeList,
 				Computed:    true,
-				Description: "Map with the role dinamically generated information",
+				Description: "Map with the role dynamically generated information",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"cardinality": {
@@ -335,17 +335,7 @@ func resourceOpennebulaServiceRead(ctx context.Context, d *schema.ResourceData, 
 				})
 				return diags
 			}
-			idFloat, ok := idInterface.(float64)
-			if !ok {
-				diags = append(diags, diag.Diagnostic{
-					Severity: diag.Error,
-					Summary:  "Failed to convert network ID to float64",
-					Detail:   fmt.Sprintf("service (ID: %s): Failed to convert network ID to float64", d.Id()),
-				})
-				return diags
-			}
-			s := strconv.Itoa(int(idFloat))
-			networkID, err := strconv.ParseInt(s, 10, 0)
+			networkID, err := ParseIntFromInterface(idInterface)
 			if err != nil {
 				diags = append(diags, diag.Diagnostic{
 					Severity: diag.Error,
@@ -354,7 +344,7 @@ func resourceOpennebulaServiceRead(ctx context.Context, d *schema.ResourceData, 
 				})
 				return diags
 			}
-			networks[k] = int(networkID)
+			networks[k] = networkID
 		}
 	}
 	d.Set("networks", networks)


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

GOCA defines networks_values as:

```
NetworksVals    []map[string]interface{} `json:"networks_values,omitempty"`
```

which as unspecified as it could be allows for both numeric and string network IDs.

This PR makes the following snippet work:

```hcl
resource "opennebula_service" "service" {
  name = "service"

  template_id = opennebula_service_template.service.id

  extra_template = jsonencode({
      networks_values = [
        { service = { id = data.opennebula_virtual_network.service.id } },
        { private = { id = tonumber(opennebula_virtual_network.reservation.id) } },
      ]
  })
}
```

### References

#000

### New or Affected Resource(s)

<!--- Please list the new or affected resources and data sources. --->

- opennebula_service

### Checklist

<!--- Please check you didn't forgot a step to help us merging this PR. --->

- [ ] I have created an issue and I have mentioned it in `References`
- [ ] My code follows the style guidelines of this project (use `go fmt`)
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the unit tests and they pass succesfuly
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation (if needed)
- [ ] I have updated the changelog file
