### PR TITLE
b-515: Corrects vlan_id prevalence in vnet creation

### DIFF
--- a/opennebula/resource_opennebula_virtual_network.go
+++ b/opennebula/resource_opennebula_virtual_network.go
@@ -803,11 +803,11 @@ func generateVn(d *schema.ResourceData) (string, error) {
 	tpl.Add(vnk.VNMad, vnmad)
 
 	vlanSet := false
-	if d.Get("automatic_vlan_id").(bool) {
-		tpl.Add("AUTOMATIC_VLAN_ID", "YES")
-		vlanSet = true
-	} else if vlanid, ok := d.GetOk("vlan_id"); ok {
+	if vlanid, ok := d.GetOk("vlan_id"); ok {
 		tpl.Add(vnk.VlanID, vlanid.(string))
+		vlanSet = true
+	} else if d.Get("automatic_vlan_id").(bool) {
+		tpl.Add("AUTOMATIC_VLAN_ID", "YES")
 		vlanSet = true
 	}
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description
Some suggestions for **https://github.com/OpenNebula/terraform-provider-opennebula/pull/561**

* Corrects `vlan_id` and `automatic_vlan_id` precedence, and refactors conditional.
* Adds some tests for checking conflict between `vlan_id` and `automatic_vlan_id` and the fixed bug.
* Some formatting

### References
#561 
#515 

### New or Affected Resource(s)

<!--- Please list the new or affected resources and data sources. --->

- opennebula_virtual_network

### Checklist

<!--- Please check you didn't forgot a step to help us merging this PR. --->

- [ ] I have created an issue and I have mentioned it in `References`
- [x] My code follows the style guidelines of this project (use `go fmt`)
- [x] My changes generate no new warnings or errors
- [x] I have updated the unit tests and they pass succesfuly
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation (if needed)
- [ ] I have updated the changelog file
