### PR TITLE
f-#: Adds a flag for debugging the provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.4.2 (Unreleased)
+
+FEATURES:
+
+* provider: Added a `--debug` flag for enabling provider debugging (#582)
+
 # 1.4.1 (October 22nd, 2024)
 
 FEATURES:

--- a/main.go
+++ b/main.go
@@ -1,15 +1,24 @@
 package main
 
 import (
+	"flag"
+
 	"github.com/OpenNebula/terraform-provider-opennebula/opennebula"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 )
 
 func main() {
+	var debug bool
+
+	flag.BoolVar(&debug, "debug", false, "set to true to run the provider with support for debuggers like delve")
+	flag.Parse()
+
 	plugin.Serve(&plugin.ServeOpts{
+		Debug: debug,
 		ProviderFunc: func() *schema.Provider {
 			return opennebula.Provider()
 		},
+		ProviderAddr: "OpenNebula/opennebula",
 	})
 }


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

Adding a "--debug" flag and setting the `ProviderAddr` will allow us to easily debug the opennebula terraform provider using delve or VSCode, for instance.

Added documentation for debugging the provider and the tests through VSCode.

More info: https://developer.hashicorp.com/terraform/plugin/debugging#enabling-debugging-in-a-provider

### References

#000

### New or Affected Resource(s)

<!--- Please list the new or affected resources and data sources. --->

- opennebula provider

### Checklist

<!--- Please check you didn't forgot a step to help us merging this PR. --->

- [ ] I have created an issue and I have mentioned it in `References`
- [x] My code follows the style guidelines of this project (use `go fmt`)
- [x] My changes generate no new warnings or errors
- [ ] I have updated the unit tests and they pass succesfuly
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation (if needed)
- [ ] I have updated the changelog file
