### PR TITLE
Improve and fix ip6 support

### DIFF
--- a/opennebula/helpers_vnet.go
+++ b/opennebula/helpers_vnet.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-version"
@@ -29,7 +30,12 @@ func getARTemplate(AR *vn.AR) *vn.AddressRange {
 	}
 
 	for i := 0; i < ARValue.NumField(); i++ {
-		ARTemplate.AddPair(typeOfAR.Field(i).Name, ARValue.Field(i).Interface())
+		fieldName := typeOfAR.Field(i).Name
+		xmlTag := typeOfAR.Field(i).Tag.Get("xml")
+		if splitted := strings.Split(xmlTag, ","); len(splitted) > 0 {
+			fieldName = splitted[0]
+		}
+		ARTemplate.AddPair(fieldName, ARValue.Field(i).Interface())
 	}
 
 	log.Printf("[DEBUG] AR template: %s", ARTemplate.String())
@@ -120,7 +126,7 @@ func vNetARAdd(ctx context.Context, timeout time.Duration, vnc *goca.VirtualNetw
 		return -1, err
 	}
 
-	arID, _ := attachedAR.GetI("ID")
+	arID, _ := attachedAR.GetI("AR_ID")
 
 	return arID, nil
 }

--- a/opennebula/helpers_vr.go
+++ b/opennebula/helpers_vr.go
@@ -108,6 +108,11 @@ func vrNICAttach(ctx context.Context, timeout time.Duration, controller *goca.Co
 						nic.Add("IP", vrouterIP)
 					}
 				}
+				if vrouterIP6, err := nic.GetStr("VROUTER_IP6"); err == nil {
+					if _, err = nic.GetStr("IP6"); err != nil {
+						nic.Add("IP6", vrouterIP6)
+					}
+				}
 				for _, pair := range nicTpl.Pairs {
 
 					value, err := nic.GetStr(pair.Key())

--- a/opennebula/resource_opennebula_virtual_network.go
+++ b/opennebula/resource_opennebula_virtual_network.go
@@ -106,21 +106,21 @@ func resourceOpennebulaVirtualNetwork() *schema.Resource {
 				Optional:      true,
 				Computed:      true,
 				Description:   "Name of the bridge interface to which the vnet should be associated",
-				ConflictsWith: []string{"reservation_vnet", "reservation_size", "reservation_ar_id", "reservation_first_ip"},
+				ConflictsWith: []string{"reservation_vnet", "reservation_size", "reservation_ar_id", "reservation_first_ip", "reservation_first_ip6"},
 			},
 			"physical_device": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				Computed:      true,
 				Description:   "Name of the physical device to which the vnet should be associated",
-				ConflictsWith: []string{"reservation_vnet", "reservation_size", "reservation_ar_id", "reservation_first_ip"},
+				ConflictsWith: []string{"reservation_vnet", "reservation_size", "reservation_ar_id", "reservation_first_ip", "reservation_first_ip6"},
 			},
 			"type": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				Default:       "bridge",
 				Description:   "Type of the Virtual Network: dummy, bridge, fw, ebtables, 802.1Q, vxlan, ovswitch. Default is 'bridge'",
-				ConflictsWith: []string{"reservation_vnet", "reservation_size", "reservation_ar_id", "reservation_first_ip"},
+				ConflictsWith: []string{"reservation_vnet", "reservation_size", "reservation_ar_id", "reservation_first_ip", "reservation_first_ip6"},
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
 					validtypes := []string{"dummy", "bridge", "fw", "ebtables", "802.1Q", "vxlan", "ovswitch"}
 					value := v.(string)
@@ -147,40 +147,40 @@ func resourceOpennebulaVirtualNetwork() *schema.Resource {
 				Optional:      true,
 				Computed:      true,
 				Description:   "VLAN ID. Only if 'Type' is : 802.1Q, vxlan or ovswich and if 'automatic_vlan_id' is not set",
-				ConflictsWith: []string{"reservation_vnet", "reservation_size", "reservation_ar_id", "reservation_first_ip", "automatic_vlan_id"},
+				ConflictsWith: []string{"reservation_vnet", "reservation_size", "reservation_ar_id", "reservation_first_ip", "reservation_first_ip6", "automatic_vlan_id"},
 			},
 			"automatic_vlan_id": {
 				Type:          schema.TypeBool,
 				Optional:      true,
 				Computed:      true,
 				Description:   "If set, let OpenNebula to attribute VLAN ID",
-				ConflictsWith: []string{"reservation_vnet", "reservation_size", "reservation_ar_id", "reservation_first_ip", "vlan_id"},
+				ConflictsWith: []string{"reservation_vnet", "reservation_size", "reservation_ar_id", "reservation_first_ip", "reservation_first_ip6", "vlan_id"},
 			},
 			"mtu": {
 				Type:          schema.TypeInt,
 				Optional:      true,
 				Description:   "MTU of the vnet (defaut: 1500)",
 				Default:       1500,
-				ConflictsWith: []string{"reservation_vnet", "reservation_size", "reservation_ar_id", "reservation_first_ip"},
+				ConflictsWith: []string{"reservation_vnet", "reservation_size", "reservation_ar_id", "reservation_first_ip", "reservation_first_ip6"},
 			},
 			"guest_mtu": {
 				Type:          schema.TypeInt,
 				Optional:      true,
 				Description:   "MTU of the Guest interface. Must be lower or equal to 'mtu' (defaut: 1500)",
 				Default:       1500,
-				ConflictsWith: []string{"reservation_vnet", "reservation_size", "reservation_ar_id", "reservation_first_ip"},
+				ConflictsWith: []string{"reservation_vnet", "reservation_size", "reservation_ar_id", "reservation_first_ip", "reservation_first_ip6"},
 			},
 			"gateway": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				Description:   "Gateway IP if necessary",
-				ConflictsWith: []string{"reservation_vnet", "reservation_size", "reservation_ar_id", "reservation_first_ip"},
+				ConflictsWith: []string{"reservation_vnet", "reservation_size", "reservation_ar_id", "reservation_first_ip", "reservation_first_ip6"},
 			},
 			"network_mask": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				Description:   "Network Mask",
-				ConflictsWith: []string{"reservation_vnet", "reservation_size", "reservation_ar_id", "reservation_first_ip"},
+				ConflictsWith: []string{"reservation_vnet", "reservation_size", "reservation_ar_id", "reservation_first_ip", "reservation_first_ip6"},
 			},
 			"network_address": {
 				Type:          schema.TypeString,
@@ -198,14 +198,14 @@ func resourceOpennebulaVirtualNetwork() *schema.Resource {
 				Type:          schema.TypeString,
 				Optional:      true,
 				Description:   "DNS IP if necessary",
-				ConflictsWith: []string{"reservation_vnet", "reservation_size", "reservation_ar_id", "reservation_first_ip"},
+				ConflictsWith: []string{"reservation_vnet", "reservation_size", "reservation_ar_id", "reservation_first_ip", "reservation_first_ip6"},
 			},
 			"ar": {
 				Type:          schema.TypeSet,
 				Optional:      true,
 				MinItems:      1,
 				Description:   "List of Address Ranges to be part of the Virtual Network",
-				ConflictsWith: []string{"reservation_vnet", "reservation_size", "reservation_ar_id", "reservation_first_ip"},
+				ConflictsWith: []string{"reservation_vnet", "reservation_size", "reservation_ar_id", "reservation_first_ip", "reservation_first_ip6"},
 				Elem: &schema.Resource{
 					Schema: ARFields(),
 				},
@@ -215,7 +215,7 @@ func resourceOpennebulaVirtualNetwork() *schema.Resource {
 				Type:          schema.TypeList,
 				Optional:      true,
 				Description:   "List of IPs to be held the VNET",
-				ConflictsWith: []string{"reservation_vnet", "reservation_size", "reservation_ar_id", "reservation_first_ip"},
+				ConflictsWith: []string{"reservation_vnet", "reservation_size", "reservation_ar_id", "reservation_first_ip", "reservation_first_ip6"},
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
@@ -238,6 +238,12 @@ func resourceOpennebulaVirtualNetwork() *schema.Resource {
 				Type:          schema.TypeString,
 				Optional:      true,
 				Description:   "First IP of the reservation",
+				ConflictsWith: []string{"bridge", "physical_device", "ar", "hold_ips", "type", "vlan_id", "automatic_vlan_id", "mtu", "dns", "gateway", "network_mask"},
+			},
+			"reservation_first_ip6": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Description:   "First IP6 of the reservation",
 				ConflictsWith: []string{"bridge", "physical_device", "ar", "hold_ips", "type", "vlan_id", "automatic_vlan_id", "mtu", "dns", "gateway", "network_mask"},
 			},
 			"reservation_ar_id": {
@@ -426,6 +432,9 @@ func resourceOpennebulaVirtualNetworkCreate(ctx context.Context, d *schema.Resou
 		}
 		if reservationFirstIP, ok := d.GetOk("reservation_first_ip"); ok {
 			reservationTemplate.AddPair("IP", reservationFirstIP.(string))
+		}
+		if reservation_first_ip6, ok := d.GetOk("reservation_first_ip6"); ok {
+			reservationTemplate.AddPair("IP6", reservation_first_ip6.(string))
 		}
 		if reservationARID := d.Get("reservation_ar_id"); reservationARID != -1 {
 			reservationTemplate.AddPair("AR_ID", reservationARID.(int))
@@ -966,12 +975,14 @@ func resourceOpennebulaVirtualNetworkRead(ctx context.Context, d *schema.Resourc
 			d.Set("reservation_ar_id", arID)
 			d.Set("reservation_size", vn.ARs[0].Size)
 			d.Set("reservation_first_ip", vn.ARs[0].IP)
+			d.Set("reservation_first_ip6", vn.ARs[0].IP6)
 		}
 	} else {
 		d.Set("reservation_vnet", -1)
 		d.Set("reservation_ar_id", -1)
 		d.Set("reservation_size", 0)
 		d.Set("reservation_first_ip", "")
+		d.Set("reservation_first_ip6", "")
 	}
 
 	cfgClusterIDs := d.Get("cluster_ids").(*schema.Set).List()

--- a/opennebula/resource_opennebula_virtual_network_address_range.go
+++ b/opennebula/resource_opennebula_virtual_network_address_range.go
@@ -280,7 +280,8 @@ func resourceOpennebulaVirtualNetworkAddressRangeRead(ctx context.Context, d *sc
 	d.Set("ip6", ar.IP6)
 	d.Set("size", ar.Size)
 	d.Set("mac", ar.MAC)
-	d.Set("ula_prefix", ar.GlobalPrefix)
+	d.Set("ula_prefix", ar.ULAPrefix)
+	d.Set("global_prefix", ar.GlobalPrefix)
 
 	cfgLeasesApplied := make([]string, 0, len(ar.Leases))
 	holdIPs := d.Get("hold_ips").(*schema.Set).List()

--- a/opennebula/resource_opennebula_virtual_network_test.go
+++ b/opennebula/resource_opennebula_virtual_network_test.go
@@ -54,6 +54,13 @@ func TestAccVirtualNetwork(t *testing.T) {
 					resource.TestCheckResourceAttr("opennebula_virtual_network_address_range.test3", "ip4", "172.16.100.130"),
 					resource.TestCheckResourceAttr("opennebula_virtual_network_address_range.test3", "hold_ips.#", "1"),
 					resource.TestCheckResourceAttr("opennebula_virtual_network_address_range.test3", "hold_ips.0", "172.16.100.131"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network_address_range.test5", "ar_type", "IP4_6"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network_address_range.test5", "size", "2"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network_address_range.test5", "ula_prefix", "fd00:ffff:ffff::"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network_address_range.test6", "ar_type", "IP4_6_STATIC"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network_address_range.test6", "size", "2"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network_address_range.test6", "ip6", "fd00:ffff:ffff::"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network_address_range.test6", "prefix_length", "127"),
 					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "tags.%", "2"),
 					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "tags.env", "prod"),
 					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "tags.customer", "test"),
@@ -108,6 +115,13 @@ func TestAccVirtualNetwork(t *testing.T) {
 					resource.TestCheckResourceAttr("opennebula_virtual_network_address_range.test3", "hold_ips.0", "172.16.100.141"),
 					resource.TestCheckResourceAttr("opennebula_virtual_network_address_range.test4", "ar_type", "IP6"),
 					resource.TestCheckResourceAttr("opennebula_virtual_network_address_range.test4", "size", "2"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network_address_range.test5", "ar_type", "IP4_6"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network_address_range.test5", "size", "2"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network_address_range.test5", "ula_prefix", "fd00:ffff:ffff::"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network_address_range.test6", "ar_type", "IP4_6_STATIC"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network_address_range.test6", "size", "2"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network_address_range.test6", "ip6", "fd00:ffff:ffff::"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network_address_range.test6", "prefix_length", "127"),
 					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "tags.%", "3"),
 					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "tags.env", "dev"),
 					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "tags.customer", "test"),
@@ -164,6 +178,13 @@ func TestAccVirtualNetwork(t *testing.T) {
 					resource.TestCheckResourceAttr("opennebula_virtual_network_address_range.test3", "hold_ips.0", "172.16.100.141"),
 					resource.TestCheckResourceAttr("opennebula_virtual_network_address_range.test4", "ar_type", "IP6"),
 					resource.TestCheckResourceAttr("opennebula_virtual_network_address_range.test4", "size", "2"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network_address_range.test5", "ar_type", "IP4_6"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network_address_range.test5", "size", "2"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network_address_range.test5", "ula_prefix", "fd00:ffff:ffff::"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network_address_range.test6", "ar_type", "IP4_6_STATIC"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network_address_range.test6", "size", "2"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network_address_range.test6", "ip6", "fd00:ffff:ffff::"),
+					resource.TestCheckResourceAttr("opennebula_virtual_network_address_range.test6", "prefix_length", "127"),
 					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "tags.%", "3"),
 					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "tags.env", "dev"),
 					resource.TestCheckResourceAttr("opennebula_virtual_network.test", "tags.customer", "test"),
@@ -387,6 +408,22 @@ resource "opennebula_virtual_network_address_range" "test3" {
 	ip4                = "172.16.100.130"
 	hold_ips           = ["172.16.100.131"]
 }
+
+resource "opennebula_virtual_network_address_range" "test5" {
+	virtual_network_id = opennebula_virtual_network.test.id
+	ar_type            = "IP4_6"
+	size               = 2
+	ip4                = "172.16.100.240"
+    ula_prefix 		   = "fd00:ffff:ffff::"
+}
+resource "opennebula_virtual_network_address_range" "test6" {
+	virtual_network_id = opennebula_virtual_network.test.id
+	ar_type            = "IP4_6_STATIC"
+	size               = 2
+	ip4                = "172.16.100.242"
+    ip6     		   = "fd00:ffff:ffff::"
+	prefix_length	   = 127
+}
 `
 
 var testAccVirtualNetworkConfigUpdate = `
@@ -449,6 +486,22 @@ resource "opennebula_virtual_network_address_range" "test4" {
 	ar_type            = "IP6"
 	size               = 2
 }
+
+resource "opennebula_virtual_network_address_range" "test5" {
+	virtual_network_id = opennebula_virtual_network.test.id
+	ar_type            = "IP4_6"
+	size               = 2
+	ip4                = "172.16.100.240"
+    ula_prefix 		   = "fd00:ffff:ffff::"
+}
+resource "opennebula_virtual_network_address_range" "test6" {
+	virtual_network_id = opennebula_virtual_network.test.id
+	ar_type            = "IP4_6_STATIC"
+	size               = 2
+	ip4                = "172.16.100.242"
+    ip6     		   = "fd00:ffff:ffff::"
+	prefix_length	   = 127
+}
 `
 
 var testAccVirtualNetworkConfigRemoveGateway = `
@@ -510,6 +563,21 @@ resource "opennebula_virtual_network_address_range" "test4" {
 	ar_type            = "IP6"
 	size               = 2
 }
+resource "opennebula_virtual_network_address_range" "test5" {
+	virtual_network_id = opennebula_virtual_network.test.id
+	ar_type            = "IP4_6"
+	size               = 2
+	ip4                = "172.16.100.240"
+    ula_prefix 		   = "fd00:ffff:ffff::"
+}
+resource "opennebula_virtual_network_address_range" "test6" {
+	virtual_network_id = opennebula_virtual_network.test.id
+	ar_type            = "IP4_6_STATIC"
+	size               = 2
+	ip4                = "172.16.100.242"
+    ip6     		   = "fd00:ffff:ffff::"
+	prefix_length	   = 127
+}
 `
 
 var testAccVirtualNetworkReservationConfig = `
@@ -564,6 +632,22 @@ resource "opennebula_virtual_network_address_range" "test4" {
 	virtual_network_id = opennebula_virtual_network.test.id
 	ar_type            = "IP6"
 	size               = 2
+}
+
+resource "opennebula_virtual_network_address_range" "test5" {
+	virtual_network_id = opennebula_virtual_network.test.id
+	ar_type            = "IP4_6"
+	size               = 2
+	ip4                = "172.16.100.240"
+    ula_prefix 		   = "fd00:ffff:ffff::"
+}
+resource "opennebula_virtual_network_address_range" "test6" {
+	virtual_network_id = opennebula_virtual_network.test.id
+	ar_type            = "IP4_6_STATIC"
+	size               = 2
+	ip4                = "172.16.100.242"
+    ip6     		   = "fd00:ffff:ffff::"
+	prefix_length	   = 127
 }
 
 resource "opennebula_virtual_network" "reservation1" {

--- a/opennebula/resource_opennebula_virtual_router_nic.go
+++ b/opennebula/resource_opennebula_virtual_router_nic.go
@@ -235,8 +235,12 @@ func resourceOpennebulaVirtualRouterNICRead(ctx context.Context, d *schema.Resou
 	// For VRouter NICs, floating IPs are set using the "IP" field, but it is represented in the ON API
 	// as the "VROUTER_IP" field.
 	if strings.ToUpper(floatingIP) == "YES" {
-		ip, _ = nic.Get("VROUTER_IP")
-		ip6, _ = nic.Get("VROUTER_IP6")
+		if vrouterIp, _ := nic.Get("VROUTER_IP"); len(vrouterIp) > 0 {
+			ip = vrouterIp
+		}
+		if vrouterIp6, _ := nic.Get("VROUTER_IP6"); len(vrouterIp6) > 0 {
+			ip6 = vrouterIp6
+		}
 	}
 
 	d.Set("network_id", networkID)

--- a/opennebula/resource_opennebula_virtual_router_nic.go
+++ b/opennebula/resource_opennebula_virtual_router_nic.go
@@ -93,6 +93,12 @@ func resourceOpennebulaVirtualRouterNIC() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 			},
+			"ip6": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -145,6 +151,10 @@ func resourceOpennebulaVirtualRouterNICCreate(ctx context.Context, d *schema.Res
 
 	if v, ok := d.GetOk("ip"); ok {
 		nicTpl.Add("IP", v.(string))
+	}
+
+	if v, ok := d.GetOk("ip6"); ok {
+		nicTpl.Add("IP6", v.(string))
 	}
 
 	// wait before checking NIC
@@ -220,11 +230,13 @@ func resourceOpennebulaVirtualRouterNICRead(ctx context.Context, d *schema.Resou
 	floatingIP, _ := nic.GetStr("FLOATING_IP")
 	floatingOnly, _ := nic.GetStr("FLOATING_ONLY")
 	ip, _ := nic.Get("IP")
+	ip6, _ := nic.Get("IP6")
 
 	// For VRouter NICs, floating IPs are set using the "IP" field, but it is represented in the ON API
 	// as the "VROUTER_IP" field.
 	if strings.ToUpper(floatingIP) == "YES" {
 		ip, _ = nic.Get("VROUTER_IP")
+		ip6, _ = nic.Get("VROUTER_IP6")
 	}
 
 	d.Set("network_id", networkID)
@@ -237,6 +249,7 @@ func resourceOpennebulaVirtualRouterNICRead(ctx context.Context, d *schema.Resou
 	d.Set("floating_ip", strings.ToUpper(floatingIP) == "YES")
 	d.Set("floating_only", strings.ToUpper(floatingOnly) == "YES")
 	d.Set("ip", ip)
+	d.Set("ip6", ip6)
 
 	return nil
 }

--- a/opennebula/resource_opennebula_virtual_router_test.go
+++ b/opennebula/resource_opennebula_virtual_router_test.go
@@ -193,9 +193,9 @@ func TestAccVirtualRouter(t *testing.T) {
 					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_floating_ip_specified", "floating_only", "false"),
 					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_floating_ip_specified", "ip", "172.16.100.160"),
 					// IP6
-					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_floating_ip6_specified", "floating_ip", "true"),
-					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_floating_ip6_specified", "floating_only", "false"),
-					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_floating_ip6_specified", "ip6", "fd00:ffff:ffff::0"),
+					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_ip6_specified", "floating_ip", "false"),
+					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_ip6_specified", "floating_only", "false"),
+					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_ip6_specified", "ip6", "fd00:ffff:ffff::1"),
 					testAccCheckVirtualRouterPermissions(&shared.Permissions{
 						OwnerU: 1,
 						OwnerM: 1,
@@ -216,12 +216,12 @@ func TestAccVirtualRouter(t *testing.T) {
 					resource.TestCheckResourceAttrSet("opennebula_virtual_router.test", "uname"),
 					resource.TestCheckResourceAttrSet("opennebula_virtual_router.test", "gname"),
 					// IP4
-					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_IP_specified", "floating_ip", "false"),
-					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_IP_specified", "floating_only", "false"),
-					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_IP_specified", "ip", "172.16.100.120"),
-					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_floating_only_IP_specified", "floating_ip", "true"),
-					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_floating_only_IP_specified", "floating_only", "true"),
-					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_floating_only_IP_specified", "ip", "172.16.100.121"),
+					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_ip_specified", "floating_ip", "false"),
+					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_ip_specified", "floating_only", "false"),
+					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_ip_specified", "ip", "172.16.100.120"),
+					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_floating_only_ip_specified", "floating_ip", "true"),
+					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_floating_only_ip_specified", "floating_only", "true"),
+					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_floating_only_ip_specified", "ip", "172.16.100.121"),
 					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_floating_ip_specified", "floating_ip", "true"),
 					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_floating_ip_specified", "floating_only", "false"),
 					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_floating_ip_specified", "ip", "172.16.100.160"),
@@ -229,12 +229,6 @@ func TestAccVirtualRouter(t *testing.T) {
 					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_ip6_specified", "floating_ip", "false"),
 					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_ip6_specified", "floating_only", "false"),
 					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_ip6_specified", "ip6", "fd00:ffff:ffff::1"),
-					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_floating_only_ip6_specified", "floating_ip", "true"),
-					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_floating_only_ip6_specified", "floating_only", "true"),
-					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_floating_only_ip6_specified", "ip6", "fd00:ffff:ffff::2"),
-					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_floating_ip6_specified", "floating_ip", "true"),
-					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_floating_ip6_specified", "floating_only", "false"),
-					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_floating_ip6_specified", "ip6", "fd00:ffff:ffff::0"),
 					testAccCheckVirtualRouterPermissions(&shared.Permissions{
 						OwnerU: 1,
 						OwnerM: 1,
@@ -416,9 +410,8 @@ resource "opennebula_virtual_network_address_range" "network3_static_ip6" {
 	ar_type            = "IP6_STATIC"
     ip6     		   = "fd00:ffff:ffff::"
 	prefix_length	   = 126
-	size			   = 10
+	size			   = 4
 }
-
 `
 
 var testAccVirtualRouterConfigBasic = testAccVirtualRouterMachineTemplate + `
@@ -672,10 +665,10 @@ resource "opennebula_virtual_router_nic" "nic_floating_ip_specified" {
     virtual_router_id = opennebula_virtual_router.test.id
     network_id        = opennebula_virtual_network.network3.id
 }
-resource "opennebula_virtual_router_nic" "nic_floating_ip6_specified" {
+
+resource "opennebula_virtual_router_nic" "nic_ip6_specified" {
     depends_on        = [opennebula_virtual_router_instance.test]
-    ip6               = "fd00:ffff:ffff::0"
-    floating_ip       = true
+    ip6               = "fd00:ffff:ffff::1"
     virtual_router_id = opennebula_virtual_router.test.id
     network_id        = opennebula_virtual_network.network3.id
 }
@@ -705,21 +698,21 @@ resource "opennebula_virtual_router" "test" {
     }
 }
 
-resource "opennebula_virtual_router_nic" "nic_IP_specified" {
+resource "opennebula_virtual_router_nic" "nic_ip_specified" {
     depends_on        = [opennebula_virtual_router_instance.test]
     ip                = "172.16.100.120"
     virtual_router_id = opennebula_virtual_router.test.id
     network_id        = opennebula_virtual_network.network2.id
 }
 
-resource "opennebula_virtual_router_nic" "nic_IP6_specified" {
+resource "opennebula_virtual_router_nic" "nic_ip6_specified" {
     depends_on        = [opennebula_virtual_router_instance.test]
     ip6               = "fd00:ffff:ffff::1"
     virtual_router_id = opennebula_virtual_router.test.id
     network_id        = opennebula_virtual_network.network3.id
 }
 
-resource "opennebula_virtual_router_nic" "nic_floating_only_IP_specified" {
+resource "opennebula_virtual_router_nic" "nic_floating_only_ip_specified" {
     depends_on        = [opennebula_virtual_router_instance.test]
     ip                = "172.16.100.121"
     floating_ip       = true
@@ -728,26 +721,9 @@ resource "opennebula_virtual_router_nic" "nic_floating_only_IP_specified" {
     network_id        = opennebula_virtual_network.network2.id
 }
 
-resource "opennebula_virtual_router_nic" "nic_floating_only_IP6_specified" {
-    depends_on        = [opennebula_virtual_router_instance.test]
-    ip6               = "fd00:ffff:ffff::2"
-    floating_ip       = true
-    floating_only     = true
-    virtual_router_id = opennebula_virtual_router.test.id
-    network_id        = opennebula_virtual_network.network3.id
-}
-
 resource "opennebula_virtual_router_nic" "nic_floating_ip_specified" {
     depends_on        = [opennebula_virtual_router_instance.test]
     ip                = "172.16.100.160"
-    floating_ip       = true
-    virtual_router_id = opennebula_virtual_router.test.id
-    network_id        = opennebula_virtual_network.network3.id
-}
-
-resource "opennebula_virtual_router_nic" "nic_floating_ip6_specified" {
-    depends_on        = [opennebula_virtual_router_instance.test]
-    ip6               = "fd00:ffff:ffff::0"
     floating_ip       = true
     virtual_router_id = opennebula_virtual_router.test.id
     network_id        = opennebula_virtual_network.network3.id

--- a/opennebula/resource_opennebula_virtual_router_test.go
+++ b/opennebula/resource_opennebula_virtual_router_test.go
@@ -188,9 +188,14 @@ func TestAccVirtualRouter(t *testing.T) {
 					resource.TestCheckResourceAttrSet("opennebula_virtual_router.test", "gid"),
 					resource.TestCheckResourceAttrSet("opennebula_virtual_router.test", "uname"),
 					resource.TestCheckResourceAttrSet("opennebula_virtual_router.test", "gname"),
+					// IP4
 					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_floating_ip_specified", "floating_ip", "true"),
 					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_floating_ip_specified", "floating_only", "false"),
 					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_floating_ip_specified", "ip", "172.16.100.160"),
+					// IP6
+					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_floating_ip6_specified", "floating_ip", "true"),
+					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_floating_ip6_specified", "floating_only", "false"),
+					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_floating_ip6_specified", "ip6", "fd00:ffff:ffff::0"),
 					testAccCheckVirtualRouterPermissions(&shared.Permissions{
 						OwnerU: 1,
 						OwnerM: 1,
@@ -210,6 +215,7 @@ func TestAccVirtualRouter(t *testing.T) {
 					resource.TestCheckResourceAttrSet("opennebula_virtual_router.test", "gid"),
 					resource.TestCheckResourceAttrSet("opennebula_virtual_router.test", "uname"),
 					resource.TestCheckResourceAttrSet("opennebula_virtual_router.test", "gname"),
+					// IP4
 					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_IP_specified", "floating_ip", "false"),
 					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_IP_specified", "floating_only", "false"),
 					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_IP_specified", "ip", "172.16.100.120"),
@@ -219,6 +225,16 @@ func TestAccVirtualRouter(t *testing.T) {
 					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_floating_ip_specified", "floating_ip", "true"),
 					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_floating_ip_specified", "floating_only", "false"),
 					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_floating_ip_specified", "ip", "172.16.100.160"),
+					// IP6
+					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_ip6_specified", "floating_ip", "false"),
+					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_ip6_specified", "floating_only", "false"),
+					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_ip6_specified", "ip6", "fd00:ffff:ffff::1"),
+					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_floating_only_ip6_specified", "floating_ip", "true"),
+					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_floating_only_ip6_specified", "floating_only", "true"),
+					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_floating_only_ip6_specified", "ip6", "fd00:ffff:ffff::2"),
+					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_floating_ip6_specified", "floating_ip", "true"),
+					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_floating_ip6_specified", "floating_only", "false"),
+					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic_floating_ip6_specified", "ip6", "fd00:ffff:ffff::0"),
 					testAccCheckVirtualRouterPermissions(&shared.Permissions{
 						OwnerU: 1,
 						OwnerM: 1,
@@ -395,6 +411,14 @@ resource "opennebula_virtual_network" "network3" {
 	security_groups = [0]
 	cluster_ids     = [0]
 }
+resource "opennebula_virtual_network_address_range" "network3_static_ip6" {
+	virtual_network_id = opennebula_virtual_network.network3.id
+	ar_type            = "IP6_STATIC"
+    ip6     		   = "fd00:ffff:ffff::"
+	prefix_length	   = 126
+	size			   = 10
+}
+
 `
 
 var testAccVirtualRouterConfigBasic = testAccVirtualRouterMachineTemplate + `
@@ -648,6 +672,13 @@ resource "opennebula_virtual_router_nic" "nic_floating_ip_specified" {
     virtual_router_id = opennebula_virtual_router.test.id
     network_id        = opennebula_virtual_network.network3.id
 }
+resource "opennebula_virtual_router_nic" "nic_floating_ip6_specified" {
+    depends_on        = [opennebula_virtual_router_instance.test]
+    ip6               = "fd00:ffff:ffff::0"
+    floating_ip       = true
+    virtual_router_id = opennebula_virtual_router.test.id
+    network_id        = opennebula_virtual_network.network3.id
+}
 `
 
 var testAccVirtualRouterUpdateNICsWithIPs = testAccVirtualRouterMachineTemplate + testAccVirtualRouterVNet + `
@@ -681,6 +712,13 @@ resource "opennebula_virtual_router_nic" "nic_IP_specified" {
     network_id        = opennebula_virtual_network.network2.id
 }
 
+resource "opennebula_virtual_router_nic" "nic_IP6_specified" {
+    depends_on        = [opennebula_virtual_router_instance.test]
+    ip6               = "fd00:ffff:ffff::1"
+    virtual_router_id = opennebula_virtual_router.test.id
+    network_id        = opennebula_virtual_network.network3.id
+}
+
 resource "opennebula_virtual_router_nic" "nic_floating_only_IP_specified" {
     depends_on        = [opennebula_virtual_router_instance.test]
     ip                = "172.16.100.121"
@@ -690,9 +728,26 @@ resource "opennebula_virtual_router_nic" "nic_floating_only_IP_specified" {
     network_id        = opennebula_virtual_network.network2.id
 }
 
+resource "opennebula_virtual_router_nic" "nic_floating_only_IP6_specified" {
+    depends_on        = [opennebula_virtual_router_instance.test]
+    ip6               = "fd00:ffff:ffff::2"
+    floating_ip       = true
+    floating_only     = true
+    virtual_router_id = opennebula_virtual_router.test.id
+    network_id        = opennebula_virtual_network.network3.id
+}
+
 resource "opennebula_virtual_router_nic" "nic_floating_ip_specified" {
     depends_on        = [opennebula_virtual_router_instance.test]
     ip                = "172.16.100.160"
+    floating_ip       = true
+    virtual_router_id = opennebula_virtual_router.test.id
+    network_id        = opennebula_virtual_network.network3.id
+}
+
+resource "opennebula_virtual_router_nic" "nic_floating_ip6_specified" {
+    depends_on        = [opennebula_virtual_router_instance.test]
+    ip6               = "fd00:ffff:ffff::0"
     floating_ip       = true
     virtual_router_id = opennebula_virtual_router.test.id
     network_id        = opennebula_virtual_network.network3.id


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description
Fixes #586. Introduces the following changes:
- Ensure AR fields are parsed correctly when reading VNet structures (using the correct XML names)
- Fix the bad `ula_prefix` in AR 
- Add the capability to create VR NIC with static IPv6
- Add `reservation_first_ip6` to `opennebula_virtual_network` to allow to create Network reservations on IP6.
- Fix the handlng of IPv6 for Vrouter NICs with floating IP6

Also add another fix which is not mentioned in the Issue but can not be introduced separately as its side effect makes tests fail:
 - Allow AR deletion to be retried on when the error is `Address Range has leases in use`. This can happen for example when a NIC is deleted and the AR deleted immediatly after. The NIC may be deleted in the ON API but the associated IP lease may take a further few seconds to actually be removed from the AR.
 
### New or Affected Resource(s)

<!--- Please list the new or affected resources and data sources. --->

- `opennebula_virtual_network_address_range`
- `opennebula_virtual_router_nic`
- `opennebula_virtual_network`


### Checklist

<!--- Please check you didn't forgot a step to help us merging this PR. --->

- [ ] I have created an issue and I have mentioned it in `References`
- [ ] My code follows the style guidelines of this project (use `go fmt`)
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the unit tests and they pass succesfuly
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation (if needed)
- [ ] I have updated the changelog file
