### PR TITLE
Support for IPv6 address information

### DIFF
--- a/opennebula/resource_opennebula_virtual_machine.go
+++ b/opennebula/resource_opennebula_virtual_machine.go
@@ -49,7 +49,17 @@ func resourceOpennebulaVirtualMachine() *schema.Resource {
 				"ip": {
 					Type:        schema.TypeString,
 					Computed:    true,
-					Description: "Primary IP address assigned by OpenNebula",
+					Description: "Primary IPv4 address assigned by OpenNebula",
+				},
+				"ip6_global": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "Primary IPv6 address assigned by OpenNebula",
+				},
+				"ip6_link": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "Link-local IPv6 address assigned by OpenNebula.",
 				},
 				"nic": nicVMSchema(),
 				"keep_nic_order": {
@@ -996,6 +1006,8 @@ func flattenVMTemplateNIC(d *schema.ResourceData, vmTemplate *vm.Template) error
 
 		if i == 0 {
 			d.Set("ip", nicRead["computed_ip"])
+			d.Set("ip6_global", nicRead["computed_ip6_global"])
+			d.Set("ip6_link", nicRead["computed_ip6_link"])
 		}
 	}
 
@@ -1010,6 +1022,8 @@ func flattenVMTemplateNIC(d *schema.ResourceData, vmTemplate *vm.Template) error
 func matchNIC(NICConfig map[string]interface{}, NIC shared.NIC) bool {
 
 	ip, _ := NIC.Get(shared.IP)
+	ip6Global, _ := NIC.GetStr("IP6_GLOBAL")
+	ip6Link, _ := NIC.GetStr("IP6_LINK")
 	mac, _ := NIC.Get(shared.MAC)
 	physicalDevice, _ := NIC.GetStr("PHYDEV")
 
@@ -1056,6 +1070,8 @@ func matchNIC(NICConfig map[string]interface{}, NIC shared.NIC) bool {
 	dns, _ := NIC.Get(shared.DNS)
 
 	return emptyOrEqual(NICConfig["ip"], ip) &&
+		emptyOrEqual(NICConfig["ip6_global"], ip6Global) &&
+		emptyOrEqual(NICConfig["ip6_link"], ip6Link) &&
 		emptyOrEqual(NICConfig["mac"], mac) &&
 		emptyOrEqual(NICConfig["physical_device"], physicalDevice) &&
 		emptyOrEqual(NICConfig["model"], model) &&
@@ -1070,6 +1086,8 @@ func matchNIC(NICConfig map[string]interface{}, NIC shared.NIC) bool {
 
 func matchNICComputed(NICConfig map[string]interface{}, NIC shared.NIC) bool {
 	ip, _ := NIC.Get(shared.IP)
+	ip6Global, _ := NIC.GetStr("IP6_GLOBAL")
+	ip6Link, _ := NIC.GetStr("IP6_LINK")
 	mac, _ := NIC.Get(shared.MAC)
 	physicalDevice, _ := NIC.GetStr("PHYDEV")
 
@@ -1099,6 +1117,8 @@ func matchNICComputed(NICConfig map[string]interface{}, NIC shared.NIC) bool {
 	dns, _ := NIC.Get(shared.DNS)
 
 	return ip == NICConfig["computed_ip"].(string) &&
+		ip6Global == NICConfig["computed_ip6_global"].(string) &&
+		ip6Link == NICConfig["computed_ip6_link"].(string) &&
 		mac == NICConfig["computed_mac"].(string) &&
 		physicalDevice == NICConfig["computed_physical_device"].(string) &&
 		model == NICConfig["computed_model"].(string) &&
@@ -1168,6 +1188,8 @@ NICLoop:
 
 		if i == 0 {
 			d.Set("ip", nicMap["computed_ip"])
+			d.Set("ip6_global", nicMap["computed_ip6_global"])
+			d.Set("ip6_link", nicMap["computed_ip6_link"])
 		}
 	}
 
@@ -2044,6 +2066,8 @@ nicCFGsLoop:
 
 			// compare other attributes
 			if (NIC["ip"] == newNIC["ip"] &&
+				NIC["ip6_global"] == newNIC["ip6_global"] &&
+				NIC["ip6_link"] == newNIC["ip6_link"] &&
 				NIC["mac"] == newNIC["mac"]) &&
 				NIC["model"] == newNIC["model"] &&
 				NIC["virtio_queues"] == newNIC["virtio_queues"] &&

--- a/opennebula/resource_opennebula_virtual_machine.go
+++ b/opennebula/resource_opennebula_virtual_machine.go
@@ -81,6 +81,14 @@ func nicComputedVMFields() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Computed: true,
 		},
+		"computed_ip6_global": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"computed_ip6_link": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
 		"computed_mac": {
 			Type:     schema.TypeString,
 			Computed: true,
@@ -870,6 +878,8 @@ func flattenNICComputed(nic shared.NIC, ignoreSGIDs []int) map[string]interface{
 	ip, _ := nic.Get(shared.IP)
 	mac, _ := nic.Get(shared.MAC)
 	physicalDevice, _ := nic.GetStr("PHYDEV")
+	ip6_global, _ := nic.GetStr("IP6_GLOBAL")
+	ip6_link, _ := nic.GetStr("IP6_LINK")
 	network, _ := nic.Get(shared.Network)
 
 	model, _ := nic.Get(shared.Model)
@@ -901,6 +911,8 @@ func flattenNICComputed(nic shared.NIC, ignoreSGIDs []int) map[string]interface{
 		"nic_id":                   nicID,
 		"network":                  network,
 		"computed_ip":              ip,
+		"computed_ip6_global":      ip6_global,
+		"computed_ip6_link":        ip6_link,
 		"computed_mac":             mac,
 		"computed_physical_device": physicalDevice,
 		"computed_model":           model,
@@ -918,6 +930,12 @@ func flattenVMNICComputed(NICConfig map[string]interface{}, NIC shared.NIC) map[
 
 	if len(NICConfig["ip"].(string)) > 0 {
 		NICMap["ip"] = NICMap["computed_ip"]
+	}
+	if len(NICConfig["ip6_global"].(string)) > 0 {
+		NICMap["ip6_global"] = NICMap["computed_ip6_global"]
+	}
+	if len(NICConfig["ip6_link"].(string)) > 0 {
+		NICMap["ip6_link"] = NICMap["computed_ip6_link"]
 	}
 	if len(NICConfig["mac"].(string)) > 0 {
 		NICMap["mac"] = NICMap["computed_mac"]

--- a/opennebula/resource_opennebula_virtual_machine.go
+++ b/opennebula/resource_opennebula_virtual_machine.go
@@ -878,8 +878,8 @@ func flattenNICComputed(nic shared.NIC, ignoreSGIDs []int) map[string]interface{
 	ip, _ := nic.Get(shared.IP)
 	mac, _ := nic.Get(shared.MAC)
 	physicalDevice, _ := nic.GetStr("PHYDEV")
-	ip6_global, _ := nic.GetStr("IP6_GLOBAL")
-	ip6_link, _ := nic.GetStr("IP6_LINK")
+	ip6Global, _ := nic.GetStr("IP6_GLOBAL")
+	ip6Link, _ := nic.GetStr("IP6_LINK")
 	network, _ := nic.Get(shared.Network)
 
 	model, _ := nic.Get(shared.Model)
@@ -911,8 +911,8 @@ func flattenNICComputed(nic shared.NIC, ignoreSGIDs []int) map[string]interface{
 		"nic_id":                   nicID,
 		"network":                  network,
 		"computed_ip":              ip,
-		"computed_ip6_global":      ip6_global,
-		"computed_ip6_link":        ip6_link,
+		"computed_ip6_global":      ip6Global,
+		"computed_ip6_link":        ip6Link,
 		"computed_mac":             mac,
 		"computed_physical_device": physicalDevice,
 		"computed_model":           model,
@@ -1960,6 +1960,8 @@ func updateNIC(ctx context.Context, d *schema.ResourceData, meta interface{}) er
 		},
 		"network_id",
 		"ip",
+		"ip6_global",
+		"ip6_link",
 		"mac",
 		"security_groups",
 		"model",

--- a/opennebula/shared_schemas.go
+++ b/opennebula/shared_schemas.go
@@ -192,6 +192,14 @@ func nicFields() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Optional: true,
 		},
+		"ip6_global": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"ip6_link": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
 		"mac": {
 			Type:     schema.TypeString,
 			Optional: true,

--- a/opennebula/shared_schemas.go
+++ b/opennebula/shared_schemas.go
@@ -192,11 +192,19 @@ func nicFields() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Optional: true,
 		},
-		"ip6_global": {
+		"ip6": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"ip6_ula": {
 			Type:     schema.TypeString,
 			Optional: true,
 		},
 		"ip6_link": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"ip6_global": {
 			Type:     schema.TypeString,
 			Optional: true,
 		},
@@ -593,6 +601,14 @@ func makeNICVector(nicConfig map[string]interface{}) *shared.NIC {
 		switch k {
 		case "ip":
 			nic.Add(shared.IP, v.(string))
+		case "ip6":
+			nic.Add(shared.IP6, v.(string))
+		case "ip6_ula":
+			nic.Add(shared.IP6_ULA, v.(string))
+		case "ip6_link":
+			nic.Add(shared.IP6_LINK, v.(string))
+		case "ip6_global":
+			nic.Add(shared.IP6_GLOBAL, v.(string))
 		case "mac":
 			nic.Add(shared.MAC, v.(string))
 		case "model":
@@ -857,6 +873,10 @@ func flattenNIC(nic shared.NIC) map[string]interface{} {
 
 	sg := make([]int, 0)
 	ip, _ := nic.Get(shared.IP)
+	ip6, _ := nic.Get(shared.IP6)
+	ip6_ula, _ := nic.Get(shared.IP6_ULA)
+	ip6_link, _ := nic.Get(shared.IP6_LINK)
+	ip6_global, _ := nic.Get(shared.IP6_GLOBAL)
 	mac, _ := nic.Get(shared.MAC)
 	physicalDevice, _ := nic.GetStr("PHYDEV")
 	network, _ := nic.Get(shared.Network)
@@ -889,6 +909,10 @@ func flattenNIC(nic shared.NIC) map[string]interface{} {
 
 	return map[string]interface{}{
 		"ip":                 ip,
+		"ip6":                ip6,
+		"ip6_ula":            ip6_ula,
+		"ip6_link":           ip6_link,
+		"ip6_global":         ip6_global,
 		"mac":                mac,
 		"network_id":         networkId,
 		"physical_device":    physicalDevice,


### PR DESCRIPTION
### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

### Description

Fixes #247. With this change, it is now possible to retrieve the IPv6 global and IPv6 link address, in addition to the IPv4 address, after creating an instance with `opennebula_virtual_machine`.

### New or Affected Resource(s)

- opennebula_virtual_machine

### Checklist

- [ ] I have created an issue and I have mentioned it in `References`
- [ ] My code follows the style guidelines of this project (use `go fmt`)
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the unit tests and they pass succesfuly
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation (if needed)
- [ ] I have updated the changelog file
