### PR TITLE
B #484: Add image field to disk schema

### DIFF
--- a/opennebula/resource_opennebula_template_test.go
+++ b/opennebula/resource_opennebula_template_test.go
@@ -197,6 +197,28 @@ func TestAccTemplate(t *testing.T) {
 					}),
 				),
 			},
+			{
+				Config: testAccTemplateImageDisk,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("opennebula_template.template_disk_test", "name", "terratplimageDisk"),
+					resource.TestCheckResourceAttr("opennebula_template.template_disk_test", "permissions", "642"),
+					resource.TestCheckResourceAttr("opennebula_template.template_disk_test", "group", "oneadmin"),
+					resource.TestCheckResourceAttr("opennebula_template.template_disk_test", "cpu", "1"),
+					resource.TestCheckResourceAttr("opennebula_template.template_disk_test", "vcpu", "1"),
+					resource.TestCheckResourceAttr("opennebula_template.template_disk_test", "memory", "768"),
+					resource.TestCheckResourceAttr("opennebula_template.template_disk_test", "disk.0.image", "imageName"),
+					resource.TestCheckResourceAttr("opennebula_template.template_disk_test", "disk.0.image_id", "-1"),
+					resource.TestCheckResourceAttr("opennebula_template.template_disk_test", "disk.#", "1"),
+					resource.TestCheckResourceAttr("opennebula_template.template_disk_test", "disk.0.target", "vda"),
+					resource.TestCheckResourceAttr("opennebula_template.template_disk_test", "disk.0.size", "64"),
+					resource.TestCheckResourceAttr("opennebula_image.image", "name", "imageName"),
+					resource.TestCheckResourceAttr("opennebula_image.image", "size", "16"),
+					resource.TestCheckResourceAttr("opennebula_image.image", "type", "DATABLOCK"),
+					resource.TestCheckResourceAttr("opennebula_image.image", "datastore_id", "1"),
+					resource.TestCheckResourceAttr("opennebula_image.image", "persistent", "false"),
+					resource.TestCheckResourceAttr("opennebula_image.image", "permissions", "660"),
+				),
+			},
 		},
 	})
 }
@@ -510,6 +532,34 @@ resource "opennebula_template" "template" {
 	elements = {
 		testkey3 = "testvalue3"
 	}
+  }
+}
+`
+
+var testAccTemplateImageDisk = `
+resource "opennebula_image" "image" {
+	name             = "imageName"
+	type             = "DATABLOCK"
+	size             = "16"
+	datastore_id     = 1
+	persistent       = false
+	permissions      = "660"
+  }
+
+
+resource "opennebula_template" "template_disk_test" {
+  name = "terratplimageDisk"
+  permissions = "642"
+  group = "oneadmin"
+
+  cpu = "1"
+  vcpu = "1"
+  memory = "768"
+
+  disk {
+	image = "imageName"
+	size     = 64
+	target   = "vda"
   }
 }
 `

--- a/website/docs/r/template.html.markdown
+++ b/website/docs/r/template.html.markdown
@@ -166,6 +166,7 @@ The following arguments are supported:
 `disk` supports the following arguments
 
 * `image_id` - (Optional) ID of the image to attach to the virtual machine. Conflicts with `volatile_type` and `volatile_format`.
+* `image` - (Optional) Name of the image to attach to the virtual machine. Conflicts with `volatile_type` and `volatile_format`.
 * `size` - (Optional) Size (in MB) of the image attached to the virtual machine. Not possible to change a cloned image size.
 * `target` - (Optional) Target name device on the virtual machine. Depends of the image `dev_prefix`.
 * `driver` - (Optional) OpenNebula image driver.
@@ -173,8 +174,8 @@ The following arguments are supported:
 * `cache` - (Optional) Selects the cache mechanism for the disk. Values are default, none, writethrough, writeback, directsync and unsafe.
 * `discard` - (Optional) Controls what’s done with with trim commands to the disk, the values can be ignore or discard.
 * `io` - (Optional) Set IO policy. Values are threads, native.
-* `volatile_type` - (Optional) Type of the volatile disk: `swap` or `fs`. Type `swap` is not supported in vcenter. Conflicts with `image_id`.
-* `volatile_format` - (Optional) Format of the volatile disk: `raw` or `qcow2`. Conflicts with `image_id`.
+* `volatile_type` - (Optional) Type of the volatile disk: `swap` or `fs`. Type `swap` is not supported in vcenter. Conflicts with `image_id` and `image`.
+* `volatile_format` - (Optional) Format of the volatile disk: `raw` or `qcow2`. Conflicts with `image_id` and `image`.
 
 Minimum 1 item. Maximum 8 items.
 

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -148,11 +148,12 @@ The following arguments are supported:
 `disk` supports the following arguments
 
 * `image_id` - (Optional) ID of the image to attach to the virtual machine. Defaults to -1 if not set: this skip Image attchment to the VM. Conflicts with `volatile_type` and `volatile_format`.
+* `image_id` - (Optional) Name of the image to attach to the virtual machine. Conflicts with `volatile_type` and `volatile_format`.
 * `size` - (Optional) Size (in MB) of the image. If set, it will resize the image disk to the targeted size. The size must be greater than the current one.
 * `target` - (Optional) Target name device on the virtual machine. Depends of the image `dev_prefix`.
 * `driver` - (Optional) OpenNebula image driver.
-* `volatile_type` - (Optional) Type of the disk: `swap` or `fs`. Type `swap` is not supported in vcenter. Conflicts with `image_id`.
-* `volatile_format` - (Optional) Format of the Image: `raw` or `qcow2`. Conflicts with `image_id`.
+* `volatile_type` - (Optional) Type of the disk: `swap` or `fs`. Type `swap` is not supported in vcenter. Conflicts with `image_id` and `image`.
+* `volatile_format` - (Optional) Format of the Image: `raw` or `qcow2`. Conflicts with `image_id` and `image`.
 
 Minimum 1 item. Maximum 8 items.
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

This PR allows defining disks by image name in VM templates
<!--- Please leave a helpful description of the PR here. --->

### References

Closes #484

### New or Affected Resource(s)

<!--- Please list the new or affected resources and data sources. --->

- opennebula_template
- opennebula_virtual_machine

### Checklist

<!--- Please check you didn't forgot a step to help us merging this PR. --->

- [ ] I have created an issue and I have mentioned it in `References`
- [ ] My code follows the style guidelines of this project (use `go fmt`)
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the unit tests and they pass succesfuly
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation (if needed)
- [ ] I have updated the changelog file
