### PR TITLE
fix: serialise firmware_secure bool as YES/NO for OpenNebula compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.5.1 (Unreleased)
+
+BUG FIXES:
+
+* resources/opennebula_virtual_machine, opennebula_template: fix `firmware_secure = true` serialising as `"true"` instead of `"YES"`, which caused OpenNebula to silently ignore the value and disable SecureBoot (#631)
+
 # 1.5.0 (June 26th, 2025)
 
 FEATURES:

--- a/opennebula/shared_schemas.go
+++ b/opennebula/shared_schemas.go
@@ -783,7 +783,11 @@ func addOS(tpl *vm.Template, os []interface{}) {
 			tpl.AddOS(vmk.SDDiskBus, osconfig["sd_disk_bus"].(string))
 			tpl.AddOS(vmk.UUID, osconfig["uuid"].(string))
 			tpl.AddOS(vmk.Firmware, osconfig["firmware"].(string))
-			tpl.AddOS(vmk.FirmwareSecure, osconfig["firmware_secure"].(bool))
+			if osconfig["firmware_secure"].(bool) {
+					tpl.AddOS(vmk.FirmwareSecure, "YES")
+				} else {
+					tpl.AddOS(vmk.FirmwareSecure, "NO")
+				}
 		}
 	}
 
@@ -1245,7 +1249,7 @@ func flattenTemplate(d *schema.ResourceData, inheritedVectors map[string]interfa
 	// Set OS to resource
 	if arch != "" {
 		firmwareSecureBool := false
-		if firmwareSecureErr == nil && firmwareSecure == "true" {
+		if firmwareSecureErr == nil && strings.EqualFold(firmwareSecure, "yes") {
 			firmwareSecureBool = true
 		}
 

--- a/opennebula/shared_schemas_test.go
+++ b/opennebula/shared_schemas_test.go
@@ -1,0 +1,34 @@
+package opennebula
+
+import (
+	"strings"
+	"testing"
+
+	vm "github.com/OpenNebula/one/src/oca/go/src/goca/schemas/vm"
+)
+
+// TestAddOS_FirmwareSecure_storesYES proves that firmware_secure=true must
+// produce FIRMWARE_SECURE="YES" in the OpenNebula template sent to the API.
+//
+// OpenNebula's Template.cc:345 only recognises "YES" (case-insensitive) as
+// boolean true. strconv.FormatBool(true) produces "true", which OpenNebula
+// silently treats as false — disabling SecureBoot despite firmware_secure=true.
+func TestAddOS_FirmwareSecure_storesYES(t *testing.T) {
+	tpl := vm.NewTemplate()
+
+	addOS(tpl, []interface{}{
+		map[string]interface{}{
+			"arch": "x86_64", "machine": "q35", "boot": "disk",
+			"kernel": "", "kernel_ds": "", "initrd": "", "initrd_ds": "",
+			"root": "", "kernel_cmd": "", "bootloader": "", "sd_disk_bus": "",
+			"uuid": "", "firmware": "/usr/share/OVMF/OVMF_CODE.secboot.fd",
+			"firmware_secure": true,
+		},
+	})
+
+	tplStr := tpl.String()
+
+	if !strings.Contains(tplStr, `FIRMWARE_SECURE="YES"`) {
+		t.Errorf("template sent to OpenNebula API:\n%s\nwant FIRMWARE_SECURE=\"YES\", OpenNebula ignores any other value", tplStr)
+	}
+}


### PR DESCRIPTION
<!-- Please keep this note for the community -->

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

<!-- Thank you for keeping this note for the community -->

### Description

`firmware_secure = true` in an `os` block was storing `FIRMWARE_SECURE = "true"` in the OpenNebula template instead of `"YES"`. OpenNebula's template parser (`Template.cc:345`) only recognises `"YES"` (case-insensitive) as boolean true, so SecureBoot was silently disabled despite the resource explicitly requesting it.

Root cause: `tpl.AddOS(vmk.FirmwareSecure, bool)` delegates to `AddPair`, which serialises a Go `bool` via `strconv.FormatBool` → `"true"`.

Fix:
- Write path: serialise explicitly as `"YES"` / `"NO"`
- Read path: compare with `strings.EqualFold(..., "yes")` instead of `== "true"`
- Added a unit test that fails before the fix and passes after

### References

#631

### New or Affected Resource(s)

- opennebula_virtual_machine
- opennebula_template

### Checklist

- [x] I have created an issue and I have mentioned it in `References`
- [x] My code follows the style guidelines of this project (use `go fmt`)
- [x] My changes generate no new warnings or errors
- [x] I have updated the unit tests and they pass succesfuly
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation (if needed)
- [x] I have updated the changelog file