### PR TITLE
Add  to VR NICs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,6 +166,29 @@ In the case of debugging the tests, we can add a configuration in the `.vscode/l
 
 Now, you can set a breakpoint in any test case and debug it executing the `Debug Terraform Provider Tests` launch configuration.
 
+## Running from CLI
+
+Building from the command line may lead to an error about the option `buildvcs`. To disable it by default execute the following:
+
+```bash
+go env -w GOFLAGS=-buildvcs=false
+```
+
+Afterwards, regular `make` commands can be issued. To execute only a certain test on a different OpenNebula server, the following variables must be defined.
+
+```
+export OPENNEBULA_ENDPOINT=http://...:2633/RPC2;
+export OPENNEBULA_USERNAME=...;
+export OPENNEBULA_PASSWORD=...;
+export OPENNEBULA_FLOW_ENDPOINT=http://...:5030;
+```
+
+To execute only a certain test the variable `TESTARGS` can be set up. For instance, to run only the `TestAccVirtualRouter` execute the following command:
+
+```
+TESTARGS="-run TestAccVirtualRouter" make testacc
+```
+
 ## Issues and Pull Requests
 
 You must use existing templates for Issues and Pull Requests.

--- a/opennebula/resource_opennebula_virtual_router_nic.go
+++ b/opennebula/resource_opennebula_virtual_router_nic.go
@@ -99,6 +99,12 @@ func resourceOpennebulaVirtualRouterNIC() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 			},
+			"routes": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -133,6 +139,9 @@ func resourceOpennebulaVirtualRouterNICCreate(ctx context.Context, d *schema.Res
 	}
 	if v, ok := d.GetOk("physical_device"); ok {
 		nicTpl.Add("PHYDEV", v.(string))
+	}
+	if v, ok := d.GetOk("routes"); ok {
+		nicTpl.Add("ROUTES", v.(string))
 	}
 	if v, ok := d.GetOk("security_groups"); ok {
 		secGroups := ArrayToString(v.([]interface{}), ",")

--- a/opennebula/resource_opennebula_virtual_router_test.go
+++ b/opennebula/resource_opennebula_virtual_router_test.go
@@ -121,10 +121,12 @@ func TestAccVirtualRouter(t *testing.T) {
 					resource.TestCheckResourceAttrSet("opennebula_virtual_router_nic.nic2", "network_id"),
 					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic1", "floating_ip", "true"),
 					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic1", "floating_only", "true"),
+					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic1", "routes", "10.0.0.0/24 via 172.16.100.8,10.1.0.0/24 via 172.16.100.8"),
 					resource.TestCheckResourceAttrSet("opennebula_virtual_router_nic.nic1", "ip"),
 					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic2", "floating_ip", "false"),
 					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic2", "floating_only", "false"),
 					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic2", "ip", ""),
+					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic2", "routes", "10.2.0.0/24 via 172.16.100.8,10.3.0.0/24 via 172.16.100.8"),
 					testAccCheckVirtualRouterPermissions(&shared.Permissions{
 						OwnerU: 1,
 						OwnerM: 1,
@@ -148,8 +150,10 @@ func TestAccVirtualRouter(t *testing.T) {
 					resource.TestCheckResourceAttrSet("opennebula_virtual_router_nic.nic2", "network_id"),
 					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic1", "floating_ip", "false"),
 					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic1", "floating_only", "false"),
+					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic1", "routes", "10.4.0.0/24 via 172.16.100.9,10.5.0.0/24 via 172.16.100.9"),
 					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic2", "floating_ip", "false"),
 					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic2", "floating_only", "false"),
+					resource.TestCheckResourceAttr("opennebula_virtual_router_nic.nic2", "routes", "10.6.0.0/24 via 172.16.100.10,10.7.0.0/24 via 172.16.100.10"),
 					testAccCheckVirtualRouterPermissions(&shared.Permissions{
 						OwnerU: 1,
 						OwnerM: 1,
@@ -553,6 +557,7 @@ resource "opennebula_virtual_router" "test" {
 resource "opennebula_virtual_router_nic" "nic2" {
     virtual_router_id = opennebula_virtual_router.test.id
     network_id        = opennebula_virtual_network.network2.id
+    routes = "10.2.0.0/24 via 172.16.100.8,10.3.0.0/24 via 172.16.100.8"
 }
 
 resource "opennebula_virtual_router_nic" "nic1" {
@@ -560,6 +565,7 @@ resource "opennebula_virtual_router_nic" "nic1" {
     floating_only     = true
     virtual_router_id = opennebula_virtual_router.test.id
     network_id        = opennebula_virtual_network.network1.id
+    routes = "10.0.0.0/24 via 172.16.100.8,10.1.0.0/24 via 172.16.100.8"
 }
 `
 var testAccVirtualRouterUpdateNICs = testAccVirtualRouterMachineTemplate + testAccVirtualRouterVNet + `
@@ -600,12 +606,14 @@ resource "opennebula_virtual_router" "test" {
 resource "opennebula_virtual_router_nic" "nic2" {
 	virtual_router_id = opennebula_virtual_router.test.id
 	network_id        = opennebula_virtual_network.network3.id
+  routes = "10.6.0.0/24 via 172.16.100.10,10.7.0.0/24 via 172.16.100.10"
 }
 
 resource "opennebula_virtual_router_nic" "nic1" {
 	floating_ip       = false
 	virtual_router_id = opennebula_virtual_router.test.id
 	network_id        = opennebula_virtual_network.network1.id
+  routes = "10.4.0.0/24 via 172.16.100.9,10.5.0.0/24 via 172.16.100.9"
 }
 `
 

--- a/website/docs/r/virtual_router_nic.markdown
+++ b/website/docs/r/virtual_router_nic.markdown
@@ -114,6 +114,7 @@ The following arguments are supported:
 * `security_groups` - (Optional) List of security group IDs to use on the virtual network.
 * `floating_ip` - (Optional) Allocate floating IP for the NIC. Defaults to `false`.
 * `floating_only` - (Optional) Do not allocate IP for the NIC. Defaults to `false`.
+* `routes` - (Optional) Comma separated static routes to be added to the NIC in format `CIDR_NET via GATEWAY` (i.e. `10.0.0.0/24 via 172.16.0.254,10.0.10.0/24 via 172.16.0.252`)
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

- Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for PR followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

Currently, Virtual router NICs do not allow custom routes. With the added parameter `ROUTES` static routes can be added to certain interface, 

### References

No references currently

### New or Affected Resource(s)

Virtual Router NIC

- `opennebula_virtual_router_nic`

### Checklist

<!--- Please check you didn't forgot a step to help us merging this PR. --->

- [x] I have created an issue and I have mentioned it in `References`
- [x] My code follows the style guidelines of this project (use `go fmt`)
- [x] My changes generate no new warnings or errors
- [] I have updated the unit tests and they pass succesfuly
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation (if needed)
- [ ] I have updated the changelog file
